### PR TITLE
Pull out schema editor components into this repo

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,4 @@
+{
+  "directory": "bower_components",
+  "registry": "https://registry.bower.io"
+}

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.sass-cache
+.tmp
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ vendor.bundle.js
 bundle.js.map
 dist/
 yarn-error.log
+.tmp
+.sass-cache
 
 # macOS
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# JS
+node_modules/
+npm-debug.log
+bundle.js
+vendor.bundle.js
+bundle.js.map
+dist/
+yarn-error.log
+
+# macOS
+.DS_Store

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,28 @@
+{
+  "node": true,
+  "browser": true,
+  "esnext": true,
+  "bitwise": true,
+  "camelcase": true,
+  "curly": true,
+  "eqeqeq": true,
+  "immed": true,
+  "indent": 4,
+  "latedef": "nofunc",
+  "newcap": true,
+  "noarg": true,
+  "quotmark": "single",
+  "undef": true,
+  "unused": true,
+  "strict": true,
+  "trailing": true,
+  "smarttabs": true,
+  "globals": {
+    "_": true,
+    "$": true,
+    "L": false,
+    "moment": true,
+    "angular": false,
+    "JSONEditor": true
+  }
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+sudo: required
+
+services:
+  - docker
+
+install:
+  - ./scripts/update
+
+script:
+  - ./scripts/test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM node:4-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  build-essential \
+  git \
+  libfontconfig \
+  ruby \
+  ruby-dev \
+  python \
+  python-dev \
+  && rm -rf /var/lib/apt/lists/* && \
+  npm install -g --save grunt-cli bower
+
+RUN gem install ffi -v 1.9.18
+RUN gem install sass -v 3.4.22
+RUN gem install compass
+
+RUN mkdir -p /opt/schema_editor /npm /bower
+
+WORKDIR /npm
+COPY package.json /npm/
+RUN npm install
+
+WORKDIR /bower
+COPY bower.json /bower/
+RUN bower install --allow-root --config.interactive=false --force
+
+WORKDIR /opt/schema_editor
+COPY . /opt/schema_editor
+
+ENTRYPOINT ["grunt"]

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,0 +1,487 @@
+// Generated on 2015-05-01 using generator-angular 0.11.1
+'use strict';
+
+// # Globbing
+// for performance reasons we're only matching one level down:
+// 'test/spec/{,*/}*.js'
+// use this if you want to recursively match all subfolders:
+// 'test/spec/**/*.js'
+
+module.exports = function (grunt) {
+
+  // Load grunt tasks automatically
+  require('load-grunt-tasks')(grunt);
+
+  // Time how long tasks take. Can help when optimizing build times
+  require('time-grunt')(grunt);
+
+  var modRewrite = require('connect-modrewrite');
+
+  // Configurable paths for the application
+  var appConfig = {
+    app: require('./bower.json').appPath || 'app',
+    dist: 'dist'
+  };
+
+  // Define the configuration for all the tasks
+  grunt.initConfig({
+
+    // Project settings
+    yeoman: appConfig,
+
+    // Watches files for changes and runs tasks based on the changed files
+    watch: {
+      bower: {
+        files: ['bower.json'],
+        tasks: ['wiredep']
+      },
+      js: {
+        files: ['<%= yeoman.app %>/scripts/**/*.js'],
+        tasks: ['newer:jshint:all'],
+        options: {
+          livereload: '<%= connect.options.livereload %>'
+        }
+      },
+      jsTest: {
+        files: ['test/spec/{,*/}*.js'],
+        tasks: ['newer:jshint:test', 'karma']
+      },
+      compass: {
+        files: ['<%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
+        tasks: ['compass:server', 'autoprefixer']
+      },
+      gruntfile: {
+        files: ['Gruntfile.js']
+      },
+      livereload: {
+        options: {
+          livereload: '<%= connect.options.livereload %>'
+        },
+        files: [
+          '<%= yeoman.app %>/**/*.html',
+          '.tmp/styles/{,*/}*.css',
+          '<%= yeoman.app %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}'
+        ]
+      }
+    },
+
+    // The actual grunt server settings
+    connect: {
+      options: {
+        port: 9000,
+        hostname: '0.0.0.0',
+        livereload: 35731
+      },
+      livereload: {
+        options: {
+          open: true,
+          middleware: function (connect) {
+            return [
+              connect.static('.tmp'),
+              connect()
+              .use(modRewrite(['^/editor/(.*)$ /$1 [R]']))
+              .use(
+                '/bower_components',
+                connect.static('./bower_components')
+              ),
+              connect()
+              .use(modRewrite(['^/editor/(.*)$ /$1 [R]']))
+              .use(
+                '/app/styles',
+                connect.static('./app/styles')
+              ),
+              connect.static(appConfig.app)
+            ];
+          }
+        }
+      },
+      test: {
+        options: {
+          port: 9001,
+          middleware: function (connect) {
+            return [
+              connect.static('.tmp'),
+              connect.static('test'),
+              connect().use(
+                '/bower_components',
+                connect.static('./bower_components')
+              ),
+              connect.static(appConfig.app)
+            ];
+          }
+        }
+      },
+      dist: {
+        options: {
+          open: true,
+          base: '<%= yeoman.dist %>'
+        }
+      }
+    },
+
+    // Make sure code styles are up to par and there are no obvious mistakes
+    jshint: {
+      options: {
+        jshintrc: '.jshintrc',
+        reporter: require('jshint-stylish')
+      },
+      all: {
+        src: [
+          'Gruntfile.js',
+          '<%= yeoman.app %>/scripts/**/*.js'
+        ]
+      },
+      test: {
+        options: {
+          jshintrc: 'test/.jshintrc'
+        },
+        src: ['test/spec/**/*.js']
+      }
+    },
+
+    // Empties folders to start fresh
+    clean: {
+      dist: {
+        files: [{
+          dot: true,
+          src: [
+            '.tmp',
+            '<%= yeoman.dist %>/{,*/}*',
+            '!<%= yeoman.dist %>/.git{,*/}*'
+          ]
+        }]
+      },
+      server: '.tmp'
+    },
+
+    // Add vendor prefixed styles
+    autoprefixer: {
+      options: {
+        browsers: ['last 1 version']
+      },
+      server: {
+        options: {
+          map: true,
+        },
+        files: [{
+          expand: true,
+          cwd: '.tmp/styles/',
+          src: '{,*/}*.css',
+          dest: '.tmp/styles/'
+        }]
+      },
+      dist: {
+        files: [{
+          expand: true,
+          cwd: '.tmp/styles/',
+          src: '{,*/}*.css',
+          dest: '.tmp/styles/'
+        }]
+      }
+    },
+
+    // Automatically inject Bower components into the app
+    wiredep: {
+      app: {
+        src: ['<%= yeoman.app %>/index.html'],
+        exclude: [],
+        ignorePath:  /\.\.\//
+      },
+      test: {
+        devDependencies: true,
+        src: '<%= karma.unit.configFile %>',
+        ignorePath:  /\.\.\//,
+        fileTypes:{
+          js: {
+            block: /(([\s\t]*)\/{2}\s*?bower:\s*?(\S*))(\n|\r|.)*?(\/{2}\s*endbower)/gi,
+              detect: {
+                js: /'(.*\.js)'/gi
+              },
+              replace: {
+                js: '\'{{filePath}}\','
+              }
+            }
+          }
+      },
+      sass: {
+        src: ['<%= yeoman.app %>/styles/{,*/}*.{scss,sass}'],
+        ignorePath: /(\.\.\/){1,2}bower_components\//
+      }
+    },
+
+    // Compiles Sass to CSS and generates necessary files if requested
+    compass: {
+      options: {
+        sassDir: '<%= yeoman.app %>/styles',
+        cssDir: '.tmp/styles',
+        generatedImagesDir: '.tmp/images/generated',
+        imagesDir: '<%= yeoman.app %>/images',
+        javascriptsDir: '<%= yeoman.app %>/scripts',
+        fontsDir: '<%= yeoman.app %>/styles/fonts',
+        importPath: './bower_components',
+        httpImagesPath: '/images',
+        httpGeneratedImagesPath: '/images/generated',
+        httpFontsPath: '/styles/fonts',
+        relativeAssets: false,
+        assetCacheBuster: false,
+        raw: 'Sass::Script::Number.precision = 10\n'
+      },
+      dist: {
+        options: {
+          generatedImagesDir: '<%= yeoman.dist %>/images/generated'
+        }
+      },
+      server: {
+        options: {
+          sourcemap: true
+        }
+      }
+    },
+
+    // Renames files for browser caching purposes
+    filerev: {
+      dist: {
+        src: [
+          '<%= yeoman.dist %>/scripts/{,*/}*.js',
+          '<%= yeoman.dist %>/styles/{,*/}*.css',
+          '<%= yeoman.dist %>/images/{,*/}*.{png,jpg,jpeg,gif,webp,svg}',
+          '<%= yeoman.dist %>/styles/fonts/*'
+        ]
+      }
+    },
+
+    // Reads HTML for usemin blocks to enable smart builds that automatically
+    // concat, minify and revision files. Creates configurations in memory so
+    // additional tasks can operate on them
+    useminPrepare: {
+      html: '<%= yeoman.app %>/index.html',
+      options: {
+        dest: '<%= yeoman.dist %>',
+        flow: {
+          html: {
+            steps: {
+              js: ['concat', 'uglifyjs'],
+              css: ['cssmin']
+            },
+            post: {}
+          }
+        }
+      }
+    },
+
+    // Performs rewrites based on filerev and the useminPrepare configuration
+    usemin: {
+      html: ['<%= yeoman.dist %>/**/*.html'],
+      css: ['<%= yeoman.dist %>/styles/{,*/}*.css'],
+      options: {
+        assetsDirs: [
+          '<%= yeoman.dist %>',
+          '<%= yeoman.dist %>/images',
+          '<%= yeoman.dist %>/styles'
+        ]
+      }
+    },
+
+    // The following *-min tasks will produce minified files in the dist folder
+    // By default, your `index.html`'s <!-- Usemin block --> will take care of
+    // minification. These next options are pre-configured if you do not wish
+    // to use the Usemin blocks.
+    // cssmin: {
+    //   dist: {
+    //     files: {
+    //       '<%= yeoman.dist %>/styles/main.css': [
+    //         '.tmp/styles/{,*/}*.css'
+    //       ]
+    //     }
+    //   }
+    // },
+    // uglify: {
+    //   dist: {
+    //     files: {
+    //       '<%= yeoman.dist %>/scripts/scripts.js': [
+    //         '<%= yeoman.dist %>/scripts/scripts.js'
+    //       ]
+    //     }
+    //   }
+    // },
+    // concat: {
+    //   dist: {}
+    // },
+
+    imagemin: {
+      dist: {
+        files: [{
+          expand: true,
+          cwd: '<%= yeoman.app %>/images',
+          src: '{,*/}*.{png,jpg,jpeg,gif}',
+          dest: '<%= yeoman.dist %>/images'
+        }]
+      }
+    },
+
+    svgmin: {
+      dist: {
+        files: [{
+          expand: true,
+          cwd: '<%= yeoman.app %>/images',
+          src: '{,*/}*.svg',
+          dest: '<%= yeoman.dist %>/images'
+        }]
+      }
+    },
+
+    htmlmin: {
+      dist: {
+        options: {
+          collapseWhitespace: true,
+          conservativeCollapse: true,
+          collapseBooleanAttributes: false,
+          removeCommentsFromCDATA: true,
+          removeOptionalTags: true
+        },
+        files: [{
+          expand: true,
+          cwd: '<%= yeoman.dist %>',
+          src: ['scripts/**/*.html'],
+          dest: '<%= yeoman.dist %>'
+        }]
+      }
+    },
+
+    // ng-annotate tries to make the code safe for minification automatically
+    // by using the Angular long form for dependency injection.
+    ngAnnotate: {
+      dist: {
+        files: [{
+          expand: true,
+          cwd: '.tmp/concat/scripts',
+          src: '*.js',
+          dest: '.tmp/concat/scripts'
+        }]
+      }
+    },
+
+    // Replace Google CDN references
+    cdnify: {
+      dist: {
+        html: ['<%= yeoman.dist %>/*.html']
+      }
+    },
+
+    // Copies remaining files to places other tasks can use
+    copy: {
+      dist: {
+        files: [{
+          expand: true,
+          dot: true,
+          cwd: '<%= yeoman.app %>',
+          dest: '<%= yeoman.dist %>',
+          src: [
+            '*.{ico,png,txt}',
+            '**/*.html',
+            'images/{,*/}*.{webp}',
+            'styles/fonts/{,*/}*.*',
+            'builder-schemas/*.json'
+          ]
+        }, {
+          expand: true,
+          cwd: '.tmp/images',
+          dest: '<%= yeoman.dist %>/images',
+          src: ['generated/*']
+        }, {
+          expand: true,
+          cwd: '.',
+          src: 'bower_components/bootstrap-sass-official/assets/fonts/bootstrap/*',
+          dest: '<%= yeoman.dist %>'
+        }]
+      },
+      styles: {
+        expand: true,
+        cwd: '<%= yeoman.app %>/styles',
+        dest: '.tmp/styles/',
+        src: '{,*/}*.css'
+      }
+    },
+
+    // Run some tasks in parallel to speed up the build process
+    concurrent: {
+      server: [
+        'compass:server'
+      ],
+      test: [
+        'compass'
+      ],
+      dist: [
+        'compass:dist',
+        'imagemin',
+        'svgmin'
+      ]
+    },
+
+    // Test settings
+    karma: {
+      unit: {
+        configFile: 'test/karma.conf.js',
+        singleRun: true
+      }
+    }
+  });
+
+
+  grunt.registerTask('serve', 'Compile then start a connect web server', function (target) {
+    if (target === 'dist') {
+      return grunt.task.run(['build', 'connect:dist:keepalive']);
+    }
+
+    grunt.task.run([
+      'clean:server',
+      'wiredep',
+      'concurrent:server',
+      'autoprefixer:server',
+      'connect:livereload',
+      'watch'
+    ]);
+  });
+
+  grunt.registerTask('server', 'DEPRECATED TASK. Use the "serve" task instead', function (target) {
+    grunt.log.warn('The `server` task has been deprecated. Use `grunt serve` to start a server.');
+    grunt.task.run(['serve:' + target]);
+  });
+
+  grunt.registerTask('travis', [
+    'jshint:all',
+    'test'
+  ]);
+
+  grunt.registerTask('test', [
+    'newer:jshint',
+    'clean:server',
+    'wiredep',
+    'concurrent:test',
+    'autoprefixer',
+    'connect:test',
+    'karma'
+  ]);
+
+  grunt.registerTask('build', [
+    'clean:dist',
+    'wiredep',
+    'useminPrepare',
+    'concurrent:dist',
+    'autoprefixer',
+    'concat',
+    'ngAnnotate',
+    'copy:dist',
+    'cssmin',
+    'uglify',
+    'filerev',
+    'usemin',
+    'htmlmin'
+  ]);
+
+  grunt.registerTask('default', [
+    'newer:jshint',
+    'test',
+    'build'
+  ]);
+};

--- a/README.md
+++ b/README.md
@@ -1,0 +1,12 @@
+# ase
+
+This project is generated with [yo angular generator](https://github.com/yeoman/generator-angular)
+version 0.11.1.
+
+## Build & development
+
+Run `grunt` for building and `grunt serve` for preview.
+
+## Testing
+
+Running `grunt test` will run the unit tests with karma.

--- a/app/404.html
+++ b/app/404.html
@@ -1,0 +1,157 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Page Not Found</title>
+    <style>
+      ::-moz-selection {
+        background: #b3d4fc;
+        text-shadow: none;
+      }
+
+      ::selection {
+        background: #b3d4fc;
+        text-shadow: none;
+      }
+
+      html {
+        padding: 30px 10px;
+        font-size: 20px;
+        line-height: 1.4;
+        color: #737373;
+        background: #f0f0f0;
+        -webkit-text-size-adjust: 100%;
+        -ms-text-size-adjust: 100%;
+      }
+
+      html,
+      input {
+        font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+      }
+
+      body {
+        max-width: 500px;
+        _width: 500px;
+        padding: 30px 20px 50px;
+        border: 1px solid #b3b3b3;
+        border-radius: 4px;
+        margin: 0 auto;
+        box-shadow: 0 1px 10px #a7a7a7, inset 0 1px 0 #fff;
+        background: #fcfcfc;
+      }
+
+      h1 {
+        margin: 0 10px;
+        font-size: 50px;
+        text-align: center;
+      }
+
+      h1 span {
+        color: #bbb;
+      }
+
+      h3 {
+        margin: 1.5em 0 0.5em;
+      }
+
+      p {
+        margin: 1em 0;
+      }
+
+      ul {
+        padding: 0 0 0 40px;
+        margin: 1em 0;
+      }
+
+      .container {
+        max-width: 380px;
+        _width: 380px;
+        margin: 0 auto;
+      }
+
+      /* google search */
+
+      #goog-fixurl ul {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+
+      #goog-fixurl form {
+        margin: 0;
+      }
+
+      #goog-wm-qt,
+      #goog-wm-sb {
+        border: 1px solid #bbb;
+        font-size: 16px;
+        line-height: normal;
+        vertical-align: top;
+        color: #444;
+        border-radius: 2px;
+      }
+
+      #goog-wm-qt {
+        width: 220px;
+        height: 20px;
+        padding: 5px;
+        margin: 5px 10px 0 0;
+        box-shadow: inset 0 1px 1px #ccc;
+      }
+
+      #goog-wm-sb {
+        display: inline-block;
+        height: 32px;
+        padding: 0 10px;
+        margin: 5px 0 0;
+        white-space: nowrap;
+        cursor: pointer;
+        background-color: #f5f5f5;
+        background-image: -webkit-linear-gradient(rgba(255,255,255,0), #f1f1f1);
+        background-image: -moz-linear-gradient(rgba(255,255,255,0), #f1f1f1);
+        background-image: -ms-linear-gradient(rgba(255,255,255,0), #f1f1f1);
+        background-image: -o-linear-gradient(rgba(255,255,255,0), #f1f1f1);
+        -webkit-appearance: none;
+        -moz-appearance: none;
+        appearance: none;
+        *overflow: visible;
+        *display: inline;
+        *zoom: 1;
+      }
+
+      #goog-wm-sb:hover,
+      #goog-wm-sb:focus {
+        border-color: #aaa;
+        box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+        background-color: #f8f8f8;
+      }
+
+      #goog-wm-qt:hover,
+      #goog-wm-qt:focus {
+        border-color: #105cb6;
+        outline: 0;
+        color: #222;
+      }
+
+      input::-moz-focus-inner {
+        padding: 0;
+        border: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="container">
+      <h1>Not found <span>:(</span></h1>
+      <p>Sorry, but the page you were trying to view does not exist.</p>
+      <p>It looks like this was the result of either:</p>
+      <ul>
+        <li>a mistyped address</li>
+        <li>an out-of-date link</li>
+      </ul>
+      <script>
+        var GOOG_FIXURL_LANG = (navigator.language || '').slice(0,2),GOOG_FIXURL_SITE = location.host;
+      </script>
+      <script src="//linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>
+    </div>
+  </body>
+</html>

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,12 @@
+
+## URL Hierarchy
+
+/recordtype/?offset=1               // get first page of recordtypes
+/recordtype/?limit=all              // list all available recordtypes
+/recordtype/add                     // Add new record type
+/recordtype/:uuid                   // list related content for recordtype
+/recordtype/:uuid/schema/add        // Add new related content type to recordtype
+/recordtype/:uuid/schema/:schema    // List fields on given schema with edit/delete controls
+
+/boundary                           // List available boundaries
+/boundary/upload                    // Upload new boundary

--- a/app/builder-schemas/related.json
+++ b/app/builder-schemas/related.json
@@ -1,0 +1,214 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "title": "Default title",
+    "description": "Default description",
+    "type": "array",
+    "items": {
+        "headerTemplate": "{{ self.fieldTitle }}",
+        "oneOf": [
+            { "$ref": "#/definitions/textField" },
+            { "$ref": "#/definitions/selectList" },
+            { "$ref": "#/definitions/imageUploader" },
+            { "$ref": "#/definitions/localReference" },
+            { "$ref": "#/definitions/numberField" }
+        ]
+    },
+    "definitions": {
+        "abstractBaseField": {
+            "type": "object",
+            "required": ["fieldTitle", "fieldType"],
+            "properties": {
+                "propertyOrder": {
+                    "type": "number",
+                    "options": {
+                        "hidden": true
+                    }
+                }
+            }
+        },
+        "abstractSearchableField": {
+            "properties": {
+                "isSearchable": {
+                    "title": "Filterable/Searchable",
+                    "type": "boolean",
+                    "format": "checkbox"
+                }
+            }
+        },
+        "abstractRequirableField": {
+            "properties": {
+                "isRequired": {
+                    "title": "Required",
+                    "type": "boolean",
+                    "format": "checkbox"
+                }
+            }
+        },
+        "textField": {
+            "allOf": [
+                { "$ref": "#/definitions/abstractBaseField" },
+                { "$ref": "#/definitions/abstractSearchableField" },
+                { "$ref": "#/definitions/abstractRequirableField" }
+            ],
+            "title": "Text Field",
+            "properties": {
+                "fieldTitle": {
+                    "title": "Text Field Title",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "textOptions": {
+                    "title": "Text Options",
+                    "type": "string",
+                    "enum": [
+                        "text",
+                        "textarea",
+                        "number",
+                        "color",
+                        "tel",
+                        "datetime",
+                        "url"
+                    ],
+                    "options": {
+                        "enum_titles": [
+                            "Single line text",
+                            "Paragraph text",
+                            "Number",
+                            "HTML Color",
+                            "Telephone number",
+                            "Date / Time",
+                            "Website URL"
+                        ]
+                    }
+                },
+                "fieldType": {
+                    "options": {
+                        "hidden": true
+                    },
+                    "type": "string",
+                    "enum": ["text"]
+                }
+            }
+        },
+        "numberField": {
+            "allOf": [
+                { "$ref": "#/definitions/abstractBaseField" },
+                { "$ref": "#/definitions/abstractSearchableField" },
+                { "$ref": "#/definitions/abstractRequirableField" }
+            ],
+            "title": "Number Field",
+            "properties": {
+                "fieldTitle": {
+                    "title": "Number Field Title",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "minimum": {
+                    "title": "Minimum Value",
+                    "type": "number"
+                },
+                "maximum": {
+                    "title": "Maximum Value",
+                    "type": "number"
+                },
+                "fieldType": {
+                    "options": {
+                        "hidden": false
+                    },
+                    "type": "string",
+                    "enum": ["number", "integer"]
+                }
+            }
+        },
+        "selectList": {
+            "allOf": [
+                { "$ref": "#/definitions/abstractBaseField" },
+                { "$ref": "#/definitions/abstractSearchableField" },
+                { "$ref": "#/definitions/abstractRequirableField" }
+            ],
+            "title": "Select List",
+            "properties": {
+                "fieldTitle": {
+                    "title": "Select List Title",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "displayType": {
+                    "title": "Display Type",
+                    "type": "string",
+                    "enum": [
+                        "select",
+                        "checkbox"
+                    ],
+                    "default": "select"
+                },
+                "fieldOptions": {
+                    "title": "Field Options",
+                    "type": "array",
+                    "format": "table",
+                    "uniqueItems": true,
+                    "minItems": 1,
+                    "items": {
+                        "title": "Option value",
+                        "type": "string"
+                    }
+                },
+                "fieldType": {
+                    "options": {
+                        "hidden": true
+                    },
+                    "type": "string",
+                    "enum": ["selectlist"]
+                }
+            }
+        },
+        "imageUploader": {
+            "allOf": [
+                { "$ref": "#/definitions/abstractBaseField" },
+                { "$ref": "#/definitions/abstractRequirableField" }
+            ],
+            "title": "Image Uploader",
+            "properties": {
+                "fieldTitle": {
+                    "title": "Image Uploader Title",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "fieldType": {
+                    "options": {
+                        "hidden": true
+                    },
+                    "type": "string",
+                    "enum": ["image"]
+                }
+            }
+        },
+        "localReference": {
+            "allOf": [
+                { "$ref": "#/definitions/abstractBaseField" },
+                { "$ref": "#/definitions/abstractRequirableField" }
+            ],
+            "title": "Relationship",
+            "properties": {
+                "fieldTitle": {
+                    "title": "Relationship Title",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "referenceTarget": {
+                    "title": "Type of related info to reference",
+                    "type": "string",
+                    "format": "select",
+                    "enumSource": [["Will be dynamically overwritten"]]
+                },
+                "fieldType": {
+                    "options": {
+                        "hidden": true
+                    },
+                    "type": "string",
+                    "enum": ["reference"]
+                }
+            }
+        }
+    }
+}

--- a/app/index.html
+++ b/app/index.html
@@ -1,0 +1,345 @@
+<!doctype html>
+<html class="no-js">
+  <head>
+    <meta charset="utf-8">
+    <title>Ashlar Editor</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width">
+    <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+    <!-- build:css(.) styles/vendor.css -->
+    <!-- bower:css -->
+    <link rel="stylesheet" href="bower_components/eonasdan-bootstrap-datetimepicker/build/css/bootstrap-datetimepicker.min.css" />
+    <link rel="stylesheet" href="bower_components/angular-spinkit/build/angular-spinkit.min.css" />
+    <link rel="stylesheet" href="bower_components/leaflet/dist/leaflet.css" />
+    <link rel="stylesheet" href="bower_components/world-calendars/redmond.calendars.picker.css" />
+    <!-- endbower -->
+    <!-- endbuild -->
+    <!-- build:css(.tmp) styles/main.css -->
+    <link rel="stylesheet" href="styles/main.css">
+    <!-- endbuild -->
+  </head>
+  <body ng-app="ase">
+    <!--[if lt IE 7]>
+      <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+    <![endif]-->
+
+    <ase-navbar></ase-navbar>
+    <div ui-view></div>
+
+    <!-- build:js(.) scripts/vendor.js -->
+    <!-- bower:js -->
+    <script src="bower_components/jquery/dist/jquery.js"></script>
+    <script src="bower_components/angular/angular.js"></script>
+    <script src="bower_components/moment/moment.js"></script>
+    <script src="bower_components/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js"></script>
+    <script src="bower_components/angular-bootstrap-datetimepicker-directive/angular-bootstrap-datetimepicker-directive.js"></script>
+    <script src="bower_components/bootstrap-sass-official/assets/javascripts/bootstrap.js"></script>
+    <script src="bower_components/angular-animate/angular-animate.js"></script>
+    <script src="bower_components/angular-aria/angular-aria.js"></script>
+    <script src="bower_components/angular-cookies/angular-cookies.js"></script>
+    <script src="bower_components/ng-file-upload/ng-file-upload.js"></script>
+    <script src="bower_components/angular-spinkit/build/angular-spinkit.js"></script>
+    <script src="bower_components/angular-resource/angular-resource.js"></script>
+    <script src="bower_components/angular-sanitize/angular-sanitize.js"></script>
+    <script src="bower_components/angular-ui-router/release/angular-ui-router.js"></script>
+    <script src="bower_components/angular-uuids/angular-uuid.js"></script>
+    <script src="bower_components/json-editor/dist/jsoneditor.js"></script>
+    <script src="bower_components/angular-local-storage/dist/angular-local-storage.js"></script>
+    <script src="bower_components/angular-bootstrap/ui-bootstrap-tpls.js"></script>
+    <script src="bower_components/lodash/lodash.js"></script>
+    <script src="bower_components/moment-timezone/builds/moment-timezone-with-data-2010-2020.js"></script>
+    <script src="bower_components/leaflet/dist/leaflet-src.js"></script>
+    <script src="bower_components/world-calendars/jquery.plugin.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.plus.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker.ext.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker.lang.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-af.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-am.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-ar-DZ.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-ar-EG.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-ar.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-az.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-bg.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-bn.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-bs.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-ca.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-cs.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-da.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-de-CH.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-de.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-el.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-en-AU.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-en-GB.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-en-NZ.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-eo.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-es-AR.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-es.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-es-PE.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-et.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-eu.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-fa.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-fi.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-fo.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-fr-CH.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-fr.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-gl.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-gu.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-he.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-hi-IN.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-hr.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-hu.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-hy.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-id.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-is.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-it.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-ja.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-ka.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-km.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-ko.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-lo.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-lt.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-lv.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-me.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-me-ME.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-mk.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-ml.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-ms.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-mt.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-nl-BE.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-nl.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-no.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-pa.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-pl.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-pt-BR.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-rm.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-ro.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-ru.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-sk.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-sl.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-sq.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-sr.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-sr-SR.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-sv.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-ta.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-th.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-tr.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-tt.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-uk.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-ur.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-vi.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-zh-CN.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-zh-HK.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars-zh-TW.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-af.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-am.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-ar-DZ.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-ar-EG.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-ar.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-az.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-bg.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-bn.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-bs.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-ca.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-cs.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-da.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-de-CH.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-de.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-el.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-en-AU.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-en-GB.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-en-NZ.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-eo.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-es-AR.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-es.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-es-PE.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-et.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-eu.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-fa.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-fi.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-fo.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-fr-CH.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-fr.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-gl.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-gu.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-he.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-hi-IN.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-hr.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-hu.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-hy.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-id.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-is.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-it.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-ja.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-ka.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-km.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-ko.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-lo.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-lt.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-lv.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-me.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-me-ME.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-mk.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-ml.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-ms.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-mt.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-nl-BE.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-nl.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-no.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-pl.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-pt-BR.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-rm.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-ro.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-ru.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-sk.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-sl.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-sq.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-sr.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-sr-SR.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-sv.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-ta.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-th.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-tr.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-tt.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-uk.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-ur.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-vi.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-zh-CN.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-zh-HK.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.picker-zh-TW.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.islamic.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.ummalqura.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.islamic-ar.js"></script>
+    <script src="bower_components/world-calendars/jquery.calendars.ummalqura-ar.js"></script>
+    <!-- endbower -->
+    <!-- endbuild -->
+
+        <!-- build:js({.tmp,app}) scripts/scripts.js -->
+        <script src="scripts/config.js"></script>
+        <script src="scripts/utils/module.js"></script>
+        <script src="scripts/utils/utils-service.js"></script>
+
+        <script src="scripts/directives/module.js"></script>
+        <script src="scripts/directives/confirm-click-directive.js"></script>
+
+        <script src="scripts/userdata/module.js"></script>
+        <script src="scripts/userdata/user-service.js"></script>
+
+        <script src="scripts/auth/module.js"></script>
+        <script src="scripts/auth/auth-service.js"></script>
+        <script src="scripts/auth/auth-interceptor.js"></script>
+        <script src="scripts/auth/logout-interceptor.js"></script>
+
+        <script src="scripts/leaflet/module.js"></script>
+        <script src="scripts/leaflet/leaflet-defaults-provider.js"></script>
+        <script src="scripts/leaflet/leaflet-map-directive.js"></script>
+
+        <script src="scripts/localization/module.js"></script>
+        <script src="scripts/localization/date-utils.js"></script>
+        <script src="scripts/localization/date-picker-directive.js"></script>
+        <script src="scripts/localization/datetime-picker-directive.js"></script>
+
+        <script src="scripts/schemas/module.js"></script>
+        <script src="scripts/schemas/schemas-service.js"></script>
+
+        <script src="scripts/resources/module.js"></script>
+        <script src="scripts/resources/builderschemas-service.js"></script>
+        <script src="scripts/resources/geography-service.js"></script>
+        <script src="scripts/resources/recordschemas-service.js"></script>
+        <script src="scripts/resources/recordtypes-service.js"></script>
+        <script src="scripts/resources/records-service.js"></script>
+
+        <script src="scripts/json-editor/module.js"></script>
+        <script src="scripts/json-editor/json-editor-defaults-service.js"></script>
+        <script src="scripts/json-editor/json-editor-directive.js"></script>
+
+        <script src="scripts/notifications/module.js"></script>
+        <script src="scripts/notifications/notifications-service.js"></script>
+        <script src="scripts/notifications/notifications-directive.js"></script>
+        <script src="scripts/notifications/notifications-controller.js"></script>
+
+        <script src="scripts/map-layers/module.js"></script>
+        <script src="scripts/map-layers/baselayers-service.js"></script>
+
+        <script src="scripts/navbar/module.js"></script>
+        <script src="scripts/navbar/navbar-controller.js"></script>
+        <script src="scripts/navbar/navbar-directive.js"></script>
+
+        <script src="scripts/details/module.js"></script>
+        <script src="scripts/details/details-field-controller.js"></script>
+        <script src="scripts/details/details-field-directive.js"></script>
+        <script src="scripts/details/details-constants-controller.js"></script>
+        <script src="scripts/details/details-constants-directive.js"></script>
+        <script src="scripts/details/details-image-controller.js"></script>
+        <script src="scripts/details/details-image-directive.js"></script>
+        <script src="scripts/details/details-integer-controller.js"></script>
+        <script src="scripts/details/details-integer-directive.js"></script>
+        <script src="scripts/details/details-multiple-controller.js"></script>
+        <script src="scripts/details/details-multiple-directive.js"></script>
+        <script src="scripts/details/details-number-controller.js"></script>
+        <script src="scripts/details/details-number-directive.js"></script>
+        <script src="scripts/details/details-reference-controller.js"></script>
+        <script src="scripts/details/details-reference-directive.js"></script>
+        <script src="scripts/details/details-selectlist-controller.js"></script>
+        <script src="scripts/details/details-selectlist-directive.js"></script>
+        <script src="scripts/details/details-single-controller.js"></script>
+        <script src="scripts/details/details-single-directive.js"></script>
+        <script src="scripts/details/details-tabs-controller.js"></script>
+        <script src="scripts/details/details-tabs-directive.js"></script>
+        <script src="scripts/details/details-text-controller.js"></script>
+        <script src="scripts/details/details-text-directive.js"></script>
+
+        <script src="scripts/views/sidebar/module.js"></script>
+        <script src="scripts/views/sidebar/cancel-bubble-directive.js"></script>
+        <script src="scripts/views/sidebar/sidebar-controller.js"></script>
+        <script src="scripts/views/sidebar/sidebar-directive.js"></script>
+
+        <script src="scripts/views/login/module.js"></script>
+        <script src="scripts/views/login/auth-controller.js"></script>
+
+        <script src="scripts/views/record/module.js"></script>
+        <script src="scripts/views/record/add-edit-controller.js"></script>
+        <script src="scripts/views/record/add-edit-directive.js"></script>
+        <script src="scripts/views/record/details-controller.js"></script>
+        <script src="scripts/views/record/details-directive.js"></script>
+        <script src="scripts/views/record/details-modal-controller.js"></script>
+        <script src="scripts/views/record/embed-map-controller.js"></script>
+        <script src="scripts/views/record/embed-map-directive.js"></script>
+        <script src="scripts/views/record/list-controller.js"></script>
+        <script src="scripts/views/record/list-directive.js"></script>
+
+        <script src="scripts/views/recordtype/module.js"></script>
+        <script src="scripts/views/recordtype/list-controller.js"></script>
+        <script src="scripts/views/recordtype/list-directive.js"></script>
+        <script src="scripts/views/recordtype/add-controller.js"></script>
+        <script src="scripts/views/recordtype/add-directive.js"></script>
+        <script src="scripts/views/recordtype/edit-controller.js"></script>
+        <script src="scripts/views/recordtype/edit-directive.js"></script>
+        <script src="scripts/views/recordtype/preview-controller.js"></script>
+        <script src="scripts/views/recordtype/preview-directive.js"></script>
+        <script src="scripts/views/recordtype/related-controller.js"></script>
+        <script src="scripts/views/recordtype/related-directive.js"></script>
+        <script src="scripts/views/recordtype/related-add-directive.js"></script>
+        <script src="scripts/views/recordtype/related-edit-directive.js"></script>
+        <script src="scripts/views/recordtype/schema/edit-controller.js"></script>
+        <script src="scripts/views/recordtype/schema/edit-directive.js"></script>
+
+        <script src="scripts/views/settings/module.js"></script>
+        <script src="scripts/views/settings/list-controller.js"></script>
+        <script src="scripts/views/settings/list-directive.js"></script>
+
+        <script src="scripts/views/usermgmt/module.js"></script>
+        <script src="scripts/views/usermgmt/list-controller.js"></script>
+        <script src="scripts/views/usermgmt/list-directive.js"></script>
+        <script src="scripts/views/usermgmt/details-controller.js"></script>
+        <script src="scripts/views/usermgmt/details-directive.js"></script>
+        <script src="scripts/views/usermgmt/edit-controller.js"></script>
+        <script src="scripts/views/usermgmt/edit-directive.js"></script>
+        <script src="scripts/views/usermgmt/add-controller.js"></script>
+        <script src="scripts/views/usermgmt/add-directive.js"></script>
+
+        <script src="scripts/app.js"></script>
+        <!-- endbuild -->
+</body>
+</html>

--- a/app/robots.txt
+++ b/app/robots.txt
@@ -1,0 +1,3 @@
+# robotstxt.org
+
+User-agent: *

--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -1,0 +1,89 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DefaultRoutingConfig($locationProvider, $urlRouterProvider, ASEConfig) {
+        $locationProvider.html5Mode(ASEConfig.html5Mode.enabled);
+        $locationProvider.hashPrefix(ASEConfig.html5Mode.prefix);
+
+        // workaround for infinite redirect when not logged in
+        // https://github.com/angular-ui/ui-router/issues/600
+        $urlRouterProvider.otherwise(function($injector) {
+            var $state = $injector.get('$state');
+            // '/recordtype'
+            $state.go('rt.list');
+        });
+    }
+
+    /* ngInject */
+    function LogConfig($logProvider, ASEConfig) {
+        $logProvider.debugEnabled(ASEConfig.debug);
+    }
+
+    /* ngInject */
+    function LocalStorageConfig(localStorageServiceProvider) {
+        localStorageServiceProvider.setPrefix('DRIVER.ASE');
+    }
+
+    /* ngInject */
+    function RunConfig($cookies, $http, $rootScope, $state, AuthService, LogoutInterceptor) {
+        // Django CSRF Token compatibility
+        $http.defaults.xsrfHeaderName = 'X-CSRFToken';
+        $http.defaults.xsrfCookieName = 'csrftoken';
+
+        $rootScope.$on('$stateChangeStart', function (event, to, toParams, from, fromParams) {
+
+            if (!AuthService.isAuthenticated()) {
+                event.preventDefault();
+                // broadcast success to avoid infinite redirect
+                // see issue: https://github.com/angular-ui/ui-router/issues/178
+                $state.go('login', null, {notify: false}).then(function() {
+                    $rootScope.$broadcast('$stateChangeSuccess', to, toParams, from, fromParams);
+                });
+                return;
+            }
+        });
+
+        $rootScope.$on(AuthService.events.loggedOut, function () {
+            $rootScope.user = null;
+        });
+
+        $rootScope.$on(LogoutInterceptor.events.logOutUser, function () {
+            AuthService.logout();
+        });
+
+        // Restore user session on full page refresh
+        if (AuthService.isAuthenticated()) {
+            $rootScope.$broadcast(AuthService.events.loggedIn);
+        }
+    }
+
+    /**
+     * @ngdoc overview
+     * @name ase
+     * @description
+     * # ase: Ashlar Schema Editor
+     *
+     * Main module of the application.
+     */
+    angular.module('ase', [
+        'ase.auth',
+        'ase.config',
+        'ase.notifications',
+        'ase.navbar',
+        'ase.views.login',
+        'ase.views.recordtype',
+        'ase.views.record',
+        'ase.views.settings',
+        'ase.views.usermgmt',
+        'ase.resources',
+        'ase.localization',
+        'ase.details',
+        'ui.router',
+        'LocalStorageModule'
+    ])
+    .config(DefaultRoutingConfig)
+    .config(LocalStorageConfig)
+    .config(LogConfig)
+    .run(RunConfig);
+})();

--- a/app/scripts/auth/auth-interceptor.js
+++ b/app/scripts/auth/auth-interceptor.js
@@ -1,0 +1,23 @@
+(function() {
+    'use strict';
+
+    /**
+     * @ngInject
+     */
+    function AuthInterceptor ($q, $cookies) {
+
+        var module = {};
+        module.request = function(config) {
+            // set auth header for api requests if not already set
+            if (config.url.indexOf('api/') > -1 && !config.headers.Authorization) {
+                config.headers.Authorization = 'Token ' + $cookies.getObject('AuthService.token');
+            }
+            return config || $q.when(config);
+        };
+
+        return module;
+    }
+
+    angular.module('ase.auth').factory('AuthInterceptor', AuthInterceptor);
+
+})();

--- a/app/scripts/auth/auth-service.js
+++ b/app/scripts/auth/auth-service.js
@@ -1,0 +1,196 @@
+(function() {
+    'use strict';
+
+    /**
+     * @ngInject
+     */
+    function AuthService($log, $q, $http, $cookies, $rootScope, $timeout, $window, ASEConfig, UserService) {
+        var module = {};
+
+        var canWriteCookieString = 'AuthService.canWrite';
+        var userIdCookieString = 'AuthService.userId';
+        var tokenCookieString = 'AuthService.token';
+        var isAdminCookieString = 'AuthService.isAdmin';
+        var cookieTimeout = null;
+        var cookieTimeoutMillis = 24 * 60 * 60 * 1000;      // 24 hours
+
+        var events = {
+            loggedIn: 'ASE:Auth:LoggedIn',
+            loggedOut: 'ASE:Auth:LoggedOut'
+        };
+
+        module.events = events;
+
+        module.isAuthenticated =  function () {
+            return !!(module.getToken() && module.getUserId() >= 0);
+        };
+
+        module.authenticate = function(auth, needsAdmin) {
+            var dfd = $q.defer();
+            $http.post(ASEConfig.api.hostname + '/api-token-auth/', auth)
+            .success(function(data, status) {
+                var result = {
+                    status: status,
+                    error: ''
+                };
+
+                if (data && data.user && data.token) {
+                    $log.debug('sending user service user:');
+                    $log.debug(data.user);
+                    $log.debug('and token');
+                    $log.debug(data.token);
+                } else {
+                    result.isAuthenticated = false;
+                    result.error = 'Error obtaining user information.';
+                    dfd.resolve(result);
+                }
+                // Need to get admin data in all cases in order to configure UI properly
+                // TODO: This results in a redundant request to the User endpoint in some cases;
+                // I attempted to refactor but ran into some difficulties with tests.
+                UserService.isAdmin(data.user, data.token).then(function(isAdmin) {
+                    // if user needs to be an admin to log in, check if they are first
+                    if (needsAdmin) {
+                        if (isAdmin) {
+                            // am an admin; log in
+                            setUserId(data.user);
+                            setToken(data.token);
+                            result.isAuthenticated = module.isAuthenticated();
+                            if (result.isAuthenticated) {
+                                // admins can write records
+                                setPermissionsCookies(true, isAdmin).then(function() {
+                                    $rootScope.$broadcast(events.loggedIn);
+                                    dfd.resolve(result);
+                                });
+                            } else {
+                                result.error = 'Unknown error logging in.';
+                                dfd.resolve(result);
+                            }
+                        } else {
+                            // user is not an admin and admin access is required
+                            $log.debug('user service sent back:');
+                            $log.debug(isAdmin);
+                            result.isAuthenticated = false;
+                            result.error = 'Must be an administrator to access this portion of the site.';
+                            dfd.resolve(result);
+                        }
+                    } else {
+                        // admin access not required; log in
+                        setUserId(data.user);
+                        setToken(data.token);
+                        result.isAuthenticated = module.isAuthenticated();
+                        if (result.isAuthenticated) {
+                            // set whether user has write access or not
+                            UserService.canWriteRecords(data.user, data.token).then(function(canWrite) {
+                                setPermissionsCookies(canWrite, isAdmin).then(function() {
+                                    $rootScope.$broadcast(events.loggedIn);
+                                    dfd.resolve(result);
+                                });
+                            });
+                        } else {
+                            result.error = 'Unknown error logging in.';
+                            setPermissionsCookies(false, false);
+                            dfd.resolve(result);
+                        }
+                    }
+                });
+            }).error(function(data, status) {
+                var error = _.values(data).join(' ');
+                if (data.username) {
+                    error = 'Username field required.';
+                }
+                if (data.password) {
+                    error = 'Password field required.';
+                }
+                var result = {
+                    isAuthenticated: false,
+                    status: status,
+                    error: error
+                };
+                dfd.resolve(result);
+            });
+
+            return dfd.promise;
+        };
+
+        module.getToken = function() {
+            return $cookies.getObject(tokenCookieString);
+        };
+
+        module.getUserId = function() {
+            var userId = parseInt($cookies.getObject(userIdCookieString), 10);
+            return isNaN(userId) ? -1 : userId;
+        };
+
+        /*
+         * Returns true if currently logged in user has write access (admin or analyst)
+         */
+        module.hasWriteAccess = function() {
+            return $cookies.getObject(canWriteCookieString) || false;
+        };
+
+        /*
+         * Returns true if currently logged in user is an admin
+         */
+        module.isAdmin = function() {
+          return $cookies.getObject(isAdminCookieString) || false;
+        };
+
+        module.logout =  function() {
+            setUserId(null);
+            $cookies.remove(tokenCookieString, {path: '/'});
+            setPermissionsCookies(false, false).then(function() {
+                $rootScope.$broadcast(events.loggedOut);
+                if (cookieTimeout) {
+                    $timeout.cancel(cookieTimeout);
+                    cookieTimeout = null;
+                }
+
+                // Redirect the user to the homepage to demonstrate that they've
+                // logged out
+                $window.location.href = '/';
+            });
+        };
+
+        return module;
+
+
+        function setPermissionsCookies(canWrite, isAdmin) {
+            // set cookie after a timeout. Angular polls every 100ms to see if there are any
+            // cookies to set; necessary to make sure cookie is set before full page refresh.
+            //
+            // https://github.com/angular/angular.js/blob/1bb33cccbe12bda4c397ddabab35ba1df85d5137/src/ng/browser.js#L102
+            // https://github.com/angular/angular.js/blob/1bb33cccbe12bda4c397ddabab35ba1df85d5137/src/ngCookies/cookies.js#L58-L66
+            return $timeout(function() {
+                $cookies.putObject(canWriteCookieString, canWrite, {path: '/'});
+                $cookies.putObject(isAdminCookieString, isAdmin, {path: '/'});
+            }, 110);
+        }
+
+        function setToken(token) {
+            if (!token) {
+                return;
+            }
+
+            // clear timeout if we re-authenticate for whatever reason
+            if (cookieTimeout) {
+                $timeout.cancel(cookieTimeout);
+                cookieTimeout = null;
+            }
+
+            $cookies.putObject(tokenCookieString, token, {path: '/'});
+
+            cookieTimeout = $timeout(function() {
+                module.logout();
+            }, cookieTimeoutMillis);
+        }
+
+        function setUserId(id) {
+            var userId = parseInt(id, 10);
+            userId = !isNaN(userId) && userId >= 0 ? userId : -1;
+            $cookies.putObject(userIdCookieString, userId, {path: '/'});
+        }
+    }
+
+    angular.module('ase.auth').factory('AuthService', AuthService);
+
+})();

--- a/app/scripts/auth/logout-interceptor.js
+++ b/app/scripts/auth/logout-interceptor.js
@@ -1,0 +1,29 @@
+(function() {
+    'use strict';
+
+    /**
+     * @ngInject
+     */
+
+    function LogoutInterceptor ($q, $rootScope) {
+
+        var module = {};
+
+        var events = {
+            logOutUser: 'ASE:Auth:LogOutUser'
+        };
+
+        module.events = events;
+        module.responseError =  function(response) {
+            if (response.status === 401) {
+                $rootScope.$broadcast(events.logOutUser);
+            }
+            return $q.reject(response);
+        };
+
+        return module;
+    }
+
+    angular.module('ase.auth').factory('LogoutInterceptor', LogoutInterceptor);
+
+})();

--- a/app/scripts/auth/module.js
+++ b/app/scripts/auth/module.js
@@ -1,0 +1,15 @@
+(function () {
+'use strict';
+
+    /* ngInject */
+    function InterceptorConfig($httpProvider) {
+        $httpProvider.interceptors.push('AuthInterceptor');
+        $httpProvider.interceptors.push('LogoutInterceptor');
+    }
+
+    angular.module('ase.auth', [
+        'ase.config',
+        'ase.userdata',
+        'ngCookies'
+      ]).config(InterceptorConfig);
+})();

--- a/app/scripts/config.js
+++ b/app/scripts/config.js
@@ -1,0 +1,35 @@
+(function () {
+    'use strict';
+
+    // Note: This module is mocked for Travis. If any changes are made to it, they should also
+    // be made in: `schema_editor/test/mock/config.js`
+    //
+    // The web project loads the resources for this project, which includes this config.
+    // The web app has its own config.js constant, which is why these are namespaced.
+
+    var config = {
+        debug: true,
+        html5Mode: {
+            enabled: false,
+            prefix: '!'
+        },
+        api: {
+            hostname: 'http://localhost:8000',
+            // These group names are defined server-side in settings.py
+            groups: {
+                admin: 'admin',
+                readOnly: 'public',
+                readWrite: 'staff'
+            }
+        },
+        record: {
+            limit: 50
+        },
+        localization: {
+            timeZone: 'America/New_York'
+        }
+    };
+
+    angular.module('ase.config', [])
+    .constant('ASEConfig', config);
+})();

--- a/app/scripts/details/details-constants-controller.js
+++ b/app/scripts/details/details-constants-controller.js
@@ -1,0 +1,13 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsConstantsController() {
+        var ctl = this;
+        ctl.dateFormat = 'long';
+    }
+
+    angular.module('ase.details')
+    .controller('DetailsConstantsController', DetailsConstantsController);
+
+})();

--- a/app/scripts/details/details-constants-directive.js
+++ b/app/scripts/details/details-constants-directive.js
@@ -1,0 +1,22 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsConstants() {
+        var module = {
+            restrict: 'AE',
+            scope: {
+                record: '<'
+            },
+            templateUrl: 'scripts/details/details-constants-partial.html',
+            bindToController: true,
+            controller: 'DetailsConstantsController',
+            controllerAs: 'ctl'
+        };
+        return module;
+    }
+
+    angular.module('ase.details')
+    .directive('aseDetailsConstants', DetailsConstants);
+
+})();

--- a/app/scripts/details/details-constants-partial.html
+++ b/app/scripts/details/details-constants-partial.html
@@ -1,0 +1,63 @@
+<div class="col-sm-6">
+    <label>
+        Occurred
+    </label>
+    <div class="value constant date occurred">
+        {{ ::ctl.record.occurred_from | localizeRecordDate: ctl.dateFormat : true }}
+        <span ng-if="::ctl.record.isSecondary && ctl.record.occurred_to">
+         - {{ ::ctl.record.occurred_to | localizeRecordDate: ctl.dateFormat : true }}
+        </span>
+    </div>
+    <label>
+        Modified
+    </label>
+    <div class="value constant date">
+        {{ ::ctl.record.modified | localizeRecordDate: ctl.dateFormat : true }}
+    </div>
+</div>
+<div class="col-sm-6">
+    <label>
+        Created
+    </label>
+    <div class="value constant date created">
+        {{ ::ctl.record.created | localizeRecordDate: 'long':'time'}}
+    </div>
+    <div ng-if="ctl.record.modified_by">
+        <label>
+            Modified By
+        </label>
+        <div class="value constant modifiedby">
+            {{ ctl.record.modified_by }}
+        </div>
+    </div>
+</div>
+<div class="col-sm-12">
+    <label>
+        Location
+    </label>
+    <div class="value constant">
+        {{ ::ctl.record.location_text }}
+    </div>
+</div>
+<div class="col-md-12">
+    <div class="map" leaflet-map embed-map
+        lat="{{ ::ctl.record.geom.coordinates[1] }}"
+        lng="{{ ::ctl.record.geom.coordinates[0] }}">
+    </div>
+</div>
+<div class="col-sm-6">
+    <label>
+        Latitude
+    </label>
+    <div class="value constant float latitude">
+        {{ ::ctl.record.geom.coordinates[1] | number:5 }}
+    </div>
+</div>
+<div class="col-sm-6">
+    <label>
+        Longitude
+    </label>
+    <div class="value constant float longitude">
+        {{ ::ctl.record.geom.coordinates[0] | number:5 }}
+    </div>
+</div>

--- a/app/scripts/details/details-field-controller.js
+++ b/app/scripts/details/details-field-controller.js
@@ -1,0 +1,11 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsFieldController() {
+    }
+
+    angular.module('ase.details')
+    .controller('DetailsFieldController', DetailsFieldController);
+
+})();

--- a/app/scripts/details/details-field-directive.js
+++ b/app/scripts/details/details-field-directive.js
@@ -1,0 +1,25 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsField() {
+        var module = {
+            restrict: 'AE',
+            scope: {
+              compact: '=',
+              data: '=',
+              property: '=',
+              record: '='
+            },
+            templateUrl: 'scripts/details/details-field-partial.html',
+            bindToController: true,
+            controller: 'DetailsFieldController',
+            controllerAs: 'ctl'
+        };
+        return module;
+    }
+
+    angular.module('ase.details')
+    .directive('aseDetailsField', DetailsField);
+
+})();

--- a/app/scripts/details/details-field-partial.html
+++ b/app/scripts/details/details-field-partial.html
@@ -1,0 +1,29 @@
+<div ng-switch on="ctl.property.fieldType">
+    <ase-details-image ng-switch-when="image"
+        property="ctl.property" data="ctl.data" compact="ctl.compact">
+    </ase-details-image>
+
+    <ase-details-reference ng-switch-when="reference"
+        property="ctl.property" data="ctl.data" record="ctl.record" compact="ctl.compact">
+    </ase-details-reference>
+
+    <ase-details-selectlist ng-switch-when="selectlist"
+        property="ctl.property" data="ctl.data" compact="ctl.compact">
+    </ase-details-selectlist>
+
+    <ase-details-text ng-switch-when="text"
+        property="ctl.property" data="ctl.data" compact="ctl.compact">
+    </ase-details-text>
+
+    <ase-details-number ng-switch-when="number"
+        property="ctl.property" data="ctl.data" compact="ctl.compact">
+    </ase-details-number>
+
+    <ase-details-integer ng-switch-when="integer"
+        property="ctl.property" data="ctl.data" compact="ctl.compact">
+    </ase-details-integer>
+
+    <div ng-switch-default>
+        "No renderer defined for field type: {{ ::property.fieldType }}
+    </div>
+</div>

--- a/app/scripts/details/details-image-controller.js
+++ b/app/scripts/details/details-image-controller.js
@@ -1,0 +1,11 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsImageController() {
+    }
+
+    angular.module('ase.details')
+    .controller('DetailsImageController', DetailsImageController);
+
+})();

--- a/app/scripts/details/details-image-directive.js
+++ b/app/scripts/details/details-image-directive.js
@@ -1,0 +1,24 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsImage() {
+        var module = {
+            restrict: 'AE',
+            scope: {
+                property: '=',
+                data: '=',
+                compact: '='
+            },
+            templateUrl: 'scripts/details/details-image-partial.html',
+            bindToController: true,
+            controller: 'DetailsImageController',
+            controllerAs: 'ctl'
+        };
+        return module;
+    }
+
+    angular.module('ase.details')
+    .directive('aseDetailsImage', DetailsImage);
+
+})();

--- a/app/scripts/details/details-image-partial.html
+++ b/app/scripts/details/details-image-partial.html
@@ -1,0 +1,9 @@
+<div ng-class="{ 'compact': ctl.compact, 'col-sm-6': !ctl.compact }">
+    <label ng-if="!ctl.compact">
+        {{ ::ctl.property.propertyName }}
+    </label>
+
+    <div class="value image">
+        <img ng-src="{{ ::ctl.data }}" />
+    </div>
+</div>

--- a/app/scripts/details/details-integer-controller.js
+++ b/app/scripts/details/details-integer-controller.js
@@ -1,0 +1,11 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsIntegerController() {
+    }
+
+    angular.module('ase.details')
+    .controller('DetailsIntegerController', DetailsIntegerController);
+
+})();

--- a/app/scripts/details/details-integer-directive.js
+++ b/app/scripts/details/details-integer-directive.js
@@ -1,0 +1,24 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsInteger() {
+        var module = {
+            restrict: 'AE',
+            scope: {
+              property: '=',
+              data: '=',
+              compact: '='
+            },
+            templateUrl: 'scripts/details/details-integer-partial.html',
+            bindToController: true,
+            controller: 'DetailsIntegerController',
+            controllerAs: 'ctl'
+        };
+        return module;
+    }
+
+    angular.module('ase.details')
+    .directive('aseDetailsInteger', DetailsInteger);
+
+})();

--- a/app/scripts/details/details-integer-partial.html
+++ b/app/scripts/details/details-integer-partial.html
@@ -1,0 +1,11 @@
+<div ng-class="{ 'compact': ctl.compact, 'col-sm-6': !ctl.compact }">
+    <label ng-if="!ctl.compact">
+        {{ ::ctl.property.propertyName }}
+    </label>
+
+    <div>
+        <div class="value integer">
+            {{ ctl.data }}
+        </div>
+    </div>
+</div>

--- a/app/scripts/details/details-multiple-controller.js
+++ b/app/scripts/details/details-multiple-controller.js
@@ -1,0 +1,13 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsMultipleController() {
+        var ctl = this;
+        ctl.maxDataColumns = 4;
+    }
+
+    angular.module('ase.details')
+    .controller('DetailsMultipleController', DetailsMultipleController);
+
+})();

--- a/app/scripts/details/details-multiple-directive.js
+++ b/app/scripts/details/details-multiple-directive.js
@@ -1,0 +1,25 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsMultiple() {
+        var module = {
+            restrict: 'AE',
+            scope: {
+                data: '=',
+                properties: '=',
+                record: '=',
+                definition: '='
+            },
+            templateUrl: 'scripts/details/details-multiple-partial.html',
+            bindToController: true,
+            controller: 'DetailsMultipleController',
+            controllerAs: 'ctl'
+        };
+        return module;
+    }
+
+    angular.module('ase.details')
+    .directive('aseDetailsMultiple', DetailsMultiple);
+
+})();

--- a/app/scripts/details/details-multiple-partial.html
+++ b/app/scripts/details/details-multiple-partial.html
@@ -1,0 +1,37 @@
+<div class="incident-report">
+    <cube-grid-spinner ng-if="ctl.definition.pending"></cube-grid-spinner>
+    <div class="table" ng-if="!ctl.definition.pending">
+        <div class="table-head">
+            <div class="row">
+                <div class="col-sm-3" ng-repeat="property in ctl.properties | limitTo : ctl.maxDataColumns">
+                    {{ ::property.propertyName }}
+                </div>
+            </div>
+        </div>
+        <div class="table-body">
+            <div class="table-body-row" ng-repeat="item in ctl.data">
+                <div class="table-body-row-header" ng-click="item.open = !item.open" ng-class="{'open': item.open}">
+                    <div class="row">
+                        <div class="col-sm-3" ng-repeat="property in ctl.properties | limitTo : ctl.maxDataColumns">
+                             <ase-details-field
+                                  compact="true"
+                                  data="::item[property.propertyName]"
+                                  record="::ctl.record"
+                                  property="::property">
+                              </ase-details-field>
+                        </div>
+                    </div>
+                </div>
+                <div class="table-body-row-content">
+                    <div class="row">
+                        <ase-details-single
+                            data="item"
+                            properties="ctl.properties"
+                            record="ctl.record">
+                        </ase-details-single>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/scripts/details/details-number-controller.js
+++ b/app/scripts/details/details-number-controller.js
@@ -1,0 +1,11 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsNumberController() {
+    }
+
+    angular.module('ase.details')
+    .controller('DetailsNumberController', DetailsNumberController);
+
+})();

--- a/app/scripts/details/details-number-directive.js
+++ b/app/scripts/details/details-number-directive.js
@@ -1,0 +1,24 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsNumber() {
+        var module = {
+            restrict: 'AE',
+            scope: {
+              property: '=',
+              data: '=',
+              compact: '='
+            },
+            templateUrl: 'scripts/details/details-number-partial.html',
+            bindToController: true,
+            controller: 'DetailsNumberController',
+            controllerAs: 'ctl'
+        };
+        return module;
+    }
+
+    angular.module('ase.details')
+    .directive('aseDetailsNumber', DetailsNumber);
+
+})();

--- a/app/scripts/details/details-number-partial.html
+++ b/app/scripts/details/details-number-partial.html
@@ -1,0 +1,11 @@
+<div ng-class="{ 'compact': ctl.compact, 'col-sm-6': !ctl.compact }">
+    <label ng-if="!ctl.compact">
+        {{ ::ctl.property.propertyName }}
+    </label>
+
+    <div>
+        <div class="value number">
+            {{ ctl.data }}
+        </div>
+    </div>
+</div>

--- a/app/scripts/details/details-reference-controller.js
+++ b/app/scripts/details/details-reference-controller.js
@@ -1,0 +1,38 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsReferenceController() {
+        var ctl = this;
+
+        var ellipsis = '...';
+
+        // Find the referenced object
+        if (ctl.record) {
+            var references = _(ctl.record.data)
+                    .toArray()
+                    .flatten()
+                    .where({ _localId: ctl.data })
+                    .value();
+
+            // Construct a display label based on the properties of the referenced object
+            if (references.length) {
+                var reference = references[0];
+                var keys = _.without(_.keys(reference), '_localId', '$$hashKey');
+                var maxKeyLength = 12;
+                ctl.referenceDisplay = _.map(keys.slice(0, 3), function(key) {
+                    if (reference[key].length < maxKeyLength) {
+                        return reference[key];
+                    }
+                    // TODO: do we need to make changes for any displayed substrings
+                    // (and limitTo filters) in the app for right-to-left languages?
+                    return reference[key].substring(0, maxKeyLength) + ellipsis;
+                }).join(' ');
+            }
+        }
+    }
+
+    angular.module('ase.details')
+    .controller('DetailsReferenceController', DetailsReferenceController);
+
+})();

--- a/app/scripts/details/details-reference-directive.js
+++ b/app/scripts/details/details-reference-directive.js
@@ -1,0 +1,25 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsReference() {
+        var module = {
+            restrict: 'AE',
+            scope: {
+                data: '=',
+                property: '=',
+                record: '=',
+                compact: '='
+            },
+            templateUrl: 'scripts/details/details-reference-partial.html',
+            bindToController: true,
+            controller: 'DetailsReferenceController',
+            controllerAs: 'ctl'
+        };
+        return module;
+    }
+
+    angular.module('ase.details')
+    .directive('aseDetailsReference', DetailsReference);
+
+})();

--- a/app/scripts/details/details-reference-partial.html
+++ b/app/scripts/details/details-reference-partial.html
@@ -1,0 +1,9 @@
+<div ng-class="{ 'compact': ctl.compact, 'col-sm-6': !ctl.compact }">
+    <label ng-if="!ctl.compact">
+        {{ ::ctl.property.propertyName }}
+    </label>
+
+    <div class="value reference">
+        {{ ::ctl.referenceDisplay }}
+    </div>
+</div>

--- a/app/scripts/details/details-selectlist-controller.js
+++ b/app/scripts/details/details-selectlist-controller.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsSelectlistController() {
+        var ctl = this;
+        init();
+
+        function init() {
+            if (Array.isArray(ctl.data)) {
+                ctl.data = ctl.data.join('; ');
+            }
+        }
+    }
+
+    angular.module('ase.details')
+    .controller('DetailsSelectlistController', DetailsSelectlistController);
+
+})();

--- a/app/scripts/details/details-selectlist-directive.js
+++ b/app/scripts/details/details-selectlist-directive.js
@@ -1,0 +1,24 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsSelectlist() {
+        var module = {
+            restrict: 'AE',
+            scope: {
+                property: '=',
+                data: '=',
+                compact: '='
+            },
+            templateUrl: 'scripts/details/details-selectlist-partial.html',
+            bindToController: true,
+            controller: 'DetailsSelectlistController',
+            controllerAs: 'ctl'
+        };
+        return module;
+    }
+
+    angular.module('ase.details')
+    .directive('aseDetailsSelectlist', DetailsSelectlist);
+
+})();

--- a/app/scripts/details/details-selectlist-partial.html
+++ b/app/scripts/details/details-selectlist-partial.html
@@ -1,0 +1,9 @@
+<div ng-class="{ 'compact': ctl.compact, 'col-sm-6': !ctl.compact }">
+    <label ng-if="!ctl.compact">
+        {{ ::ctl.property.propertyName }}
+    </label>
+
+    <div class="value selectlist">
+        {{ ::ctl.data }}
+    </div>
+</div>

--- a/app/scripts/details/details-single-controller.js
+++ b/app/scripts/details/details-single-controller.js
@@ -1,0 +1,11 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsSingleController() {
+    }
+
+    angular.module('ase.details')
+    .controller('DetailsSingleController', DetailsSingleController);
+
+})();

--- a/app/scripts/details/details-single-directive.js
+++ b/app/scripts/details/details-single-directive.js
@@ -1,0 +1,25 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsSingle() {
+        var module = {
+            restrict: 'AE',
+            scope: {
+                data: '<',
+                properties: '<',
+                record: '<',
+                definition: '<'
+            },
+            templateUrl: 'scripts/details/details-single-partial.html',
+            bindToController: true,
+            controller: 'DetailsSingleController',
+            controllerAs: 'ctl'
+        };
+        return module;
+    }
+
+    angular.module('ase.details')
+    .directive('aseDetailsSingle', DetailsSingle);
+
+})();

--- a/app/scripts/details/details-single-partial.html
+++ b/app/scripts/details/details-single-partial.html
@@ -1,0 +1,11 @@
+<cube-grid-spinner ng-if="ctl.definition.pending"></cube-grid-spinner>
+
+<ase-details-constants
+     ng-if="ctl.definition.details" record="ctl.record">
+</ase-details-constants>
+
+<div ng-repeat="property in ctl.properties" ng-if="!ctl.definition.pending">
+    <ase-details-field
+       property="property" data="ctl.data[property.propertyName]" record="ctl.record">
+    </ase-details-field>
+</div>

--- a/app/scripts/details/details-tabs-controller.js
+++ b/app/scripts/details/details-tabs-controller.js
@@ -1,0 +1,81 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsTabsController(Records, $q, $rootScope, $scope) {
+        var ctl = this;
+        ctl.sortedDefinitions = sortDefinitions();
+        ctl.sortedProperties = sortedProperties;
+
+        // Cancel pending record request, if any, when view closed
+        $scope.$on('$destroy', function() {
+            if ($rootScope.pendingRecordRequest) {
+                $rootScope.pendingRecordRequest.resolve();
+            }
+        });
+
+        function getFullRecord() {
+            // for users with full record access, go fetch all the other sections of the record
+            if (ctl.userCanWrite) {
+                // Promise that may be used to cancel the full record query.
+                // Kept on root scope so that it will still be present in scope's $destroy.
+                $rootScope.pendingRecordRequest = $q.defer();
+
+                Records.get({
+                    id: ctl.record.uuid,
+                    timeout: $rootScope.pendingRecordRequest.promise})
+                .$promise.then(function(record) {
+                    ctl.record = record;
+                    ctl.sortedDefinitions = _.map(ctl.sortedDefinitions, function(definition) {
+                        definition.pending = false;
+                        return definition;
+                    });
+                });
+            }
+        }
+
+        function sortDefinitions() {
+            // get the section names, sorted by propertyOrder
+            var ordering = _(ctl.recordSchema.schema.properties)
+                .sortBy(function(obj, key) {
+                    obj.propertyName = key;
+                    return (obj.propertyOrder !== undefined) ? obj.propertyOrder : 99;
+                })
+                .map(function(obj) {
+                    return obj.propertyName;
+                })
+                .value();
+
+
+            // get section definitions as sorted array, with added property for the section name
+            var sorted = _.map(ordering, function(section) {
+                var definition = ctl.recordSchema.schema.definitions[section];
+                definition.propertyName = definition.title;
+                definition.propertyKey = section;
+                // only set to pending if not details section and user not public
+                definition.pending = !definition.details && ctl.userCanWrite;
+                return definition;
+            });
+
+            getFullRecord();
+            return sorted;
+        }
+
+        // Returning an array of definition properties sorted by propertyOrder
+        function sortedProperties(properties) {
+            return _(properties)
+                .omit('_localId')
+                .map(function(obj, propertyName) {
+                    // The object is being converted to an array, so preserve the property name
+                    obj.propertyName = propertyName;
+                    return obj;
+                })
+                .sortBy('propertyOrder')
+                .value();
+        }
+    }
+
+    angular.module('ase.details')
+    .controller('DetailsTabsController', DetailsTabsController);
+
+})();

--- a/app/scripts/details/details-tabs-directive.js
+++ b/app/scripts/details/details-tabs-directive.js
@@ -1,0 +1,24 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsTabs() {
+        var module = {
+            restrict: 'AE',
+            scope: {
+                recordSchema: '=',
+                record: '=',
+                userCanWrite: '='
+            },
+            templateUrl: 'scripts/details/details-tabs-partial.html',
+            bindToController: true,
+            controller: 'DetailsTabsController',
+            controllerAs: 'ctl'
+        };
+        return module;
+    }
+
+    angular.module('ase.details')
+    .directive('aseDetailsTabs', DetailsTabs);
+
+})();

--- a/app/scripts/details/details-tabs-partial.html
+++ b/app/scripts/details/details-tabs-partial.html
@@ -1,0 +1,22 @@
+<tabset>
+    <tab ng-repeat="definition in ctl.sortedDefinitions"
+         heading="{{ definition.multiple ? definition.plural_title : definition.title }}"
+         ng-init="properties = ctl.sortedProperties(definition.properties)">
+
+        <ase-details-single
+            ng-if="!definition.multiple"
+            data="::ctl.record.data[definition.propertyKey]"
+            properties="::properties"
+            record="ctl.record"
+            definition="::definition">
+        </ase-details-single>
+
+        <ase-details-multiple
+            ng-if="definition.multiple"
+            data="::ctl.record.data[definition.propertyKey]"
+            properties="::properties"
+            record="::ctl.record"
+            definition="::definition">
+        </ase-details-multiple>
+    </tab>
+</tabset>

--- a/app/scripts/details/details-text-controller.js
+++ b/app/scripts/details/details-text-controller.js
@@ -1,0 +1,26 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsTextController($rootScope) {
+        var ctl = this;
+        ctl.maxLength = 20;
+
+        ctl.xShift = function() {
+            /**
+             * Magic numbers:
+             * 300 - 125 is svg-width - compact width
+             * 300 - 200 is svg.width - !compact width
+             */
+            if ($rootScope.isRightToLeft) {
+                return ctl.compact ? 300 - 125 : 300 - 200;
+            } else {
+                return 0;
+            }
+        };
+    }
+
+    angular.module('ase.details')
+    .controller('DetailsTextController', DetailsTextController);
+
+})();

--- a/app/scripts/details/details-text-directive.js
+++ b/app/scripts/details/details-text-directive.js
@@ -1,0 +1,24 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function DetailsText() {
+        var module = {
+            restrict: 'AE',
+            scope: {
+              property: '=',
+              data: '=',
+              compact: '='
+            },
+            templateUrl: 'scripts/details/details-text-partial.html',
+            bindToController: true,
+            controller: 'DetailsTextController',
+            controllerAs: 'ctl'
+        };
+        return module;
+    }
+
+    angular.module('ase.details')
+    .directive('aseDetailsText', DetailsText);
+
+})();

--- a/app/scripts/details/details-text-partial.html
+++ b/app/scripts/details/details-text-partial.html
@@ -1,0 +1,32 @@
+<div ng-class="{ 'compact': ctl.compact, 'col-sm-6': !ctl.compact }">
+    <label ng-if="!ctl.compact">
+        {{ ::ctl.property.propertyName }}
+    </label>
+
+    <div ng-switch on="ctl.property.format">
+        <div ng-switch-when="color" class="value color">
+            <svg>
+                <rect class="rectangle" rx="20" ry="20" style="fill:{{ ::ctl.data }};"
+                ng-attr-x="{{ ctl.xShift() }}"/>
+            </svg>
+        </div>
+
+        <div ng-switch-when="textarea" class="value textarea">
+            <pre ng-if="!ctl.compact">{{ ::ctl.data }}</pre>
+            <span ng-if="ctl.compact">
+                {{ ::ctl.data | limitTo: ctl.maxLength }}
+                <span ng-if="ctl.data.length > ctl.maxLength">
+                    ...
+                </span>
+            </span>
+        </div>
+
+        <div ng-switch-when="url" class="value url">
+            <a href="{{ ctl.data }}">{{ ::ctl.data }}</a>
+        </div>
+
+        <div ng-switch-default class="value text">
+            {{ ::ctl.data }}
+        </div>
+    </div>
+</div>

--- a/app/scripts/details/module.js
+++ b/app/scripts/details/module.js
@@ -1,0 +1,9 @@
+(function () {
+    'use strict';
+
+    angular.module('ase.details', [
+        'ase.resources',
+        'Leaflet',
+    ]);
+
+})();

--- a/app/scripts/directives/confirm-click-directive.js
+++ b/app/scripts/directives/confirm-click-directive.js
@@ -1,0 +1,29 @@
+/**
+ * Attribute directive which displays a confirmation dialog when an element is clicked.
+ * Usage:
+ *   <a ase-confirm-click="functionToRun()"></a>
+ */
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function ConfirmClick($window) {
+
+        var module = {
+            restrict: 'A',
+            link: link
+        };
+        return module;
+
+        function link(scope, element, attr) {
+            element.bind('click', function() {
+                if ($window.confirm('Are you sure?')) {
+                    scope.$eval(attr.aseConfirmClick);
+                }
+            });
+        }
+    }
+
+    angular.module('ase.directives')
+    .directive('aseConfirmClick', ConfirmClick);
+})();

--- a/app/scripts/directives/module.js
+++ b/app/scripts/directives/module.js
@@ -1,0 +1,6 @@
+(function () {
+    'use strict';
+
+    angular.module('ase.directives', []);
+
+})();

--- a/app/scripts/json-editor/json-editor-defaults-service.js
+++ b/app/scripts/json-editor/json-editor-defaults-service.js
@@ -1,0 +1,40 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function JsonEditorDefaults() {
+        var module = {
+            customValidators: {
+                push: pushCustomValidator,
+                pop: popCustomValidator,
+                clear: clearCustomValidators
+            },
+            addTranslation: addTranslation
+        };
+
+        /* jshint camelcase: false */
+        function pushCustomValidator(validator) {
+            return JSONEditor.defaults.custom_validators.push(validator);
+        }
+
+        function popCustomValidator() {
+            return JSONEditor.defaults.custom_validators.pop();
+        }
+
+        function clearCustomValidators() {
+            JSONEditor.defaults.custom_validators = [];
+        }
+
+        // Adds a translation mapping for the json-editor to use.
+        // To see the available keys, see `src/defaults.json` in the json-editor repo.
+        function addTranslation(key, val) {
+            JSONEditor.defaults.languages.en[key] = val;
+        }
+        /* jshint camelcase: true */
+
+        return module;
+    }
+
+    angular.module('json-editor')
+    .service('JsonEditorDefaults', JsonEditorDefaults);
+})();

--- a/app/scripts/json-editor/json-editor-directive.js
+++ b/app/scripts/json-editor/json-editor-directive.js
@@ -1,0 +1,94 @@
+/**
+ * Directive wrapper for the JSONSchema js plugin:
+ *     https://github.com/jdorn/json-editor
+ *
+ * @param {string} editorId A string identifier that can be used to retrieve the editor object
+ *                          from the associated Editor service
+ * @param {object} options A JSONEditor options object, passed directly to the constructor
+ *                         default: {}
+ * @param {function} onDataChange A function on the wrapper scope to be called when the editor
+ *                                data changes, passes new editor data as first argument.
+ *
+ * Events:
+ *      json-editor:ready
+ *          @param {JSONEditor} editor The editor object that is now ready
+ */
+(function () {
+    'use strict';
+
+    var defaults = {};
+
+    /* ngInject */
+    function JsonEditor(JsonEditorDefaults) {
+
+        var module = {
+            restrict: 'E',
+            scope: {
+                editorId: '@',
+                options: '=',
+                onDataChange: '&'
+            },
+            link: link
+        };
+        return module;
+
+        function link(scope, element) {
+            var editor = null;
+            var htmlElement = element[0];
+            var changeRef = null;
+
+            // Every time the editor options change, we need to destroy and recreate
+            // the form, preserving the user-entered data in the form
+            //
+            // Note: since the switch to using arrays as the form builder root, the options
+            // are never updated, and this destroy/recreate logic isn't run. Keeping the logic
+            // in here for the time being as it doesn't hurt anything and may be useful to
+            // someone if this is released as a standalone directive.
+            scope.$watch('options', function (newValue) {
+                if (!(newValue && newValue.schema)) {
+                    return;
+                }
+                var options = angular.extend({}, defaults, scope.options);
+
+                var oldData = null;
+                // Delete old editor
+                if (editor) {
+                    oldData = editor.getValue();
+                    editor.off('change', changeRef);
+                    editor.destroy();
+                    editor = null;
+                }
+
+                // Recreate with new options
+                editor = new JSONEditor(htmlElement, options);
+                if (oldData !== null) {
+                    // Extend new with old
+                    var newData = editor.getValue();
+                    angular.extend(newData, options.startval, oldData);
+                    editor.setValue(newData);
+                }
+                changeRef = editor.on('change', function () {
+                    var editorData = editor.getValue();
+                    var errors = editor.validate();
+                    // Bring data changes into the angular digest lifecycle
+                    scope.$apply(function() { scope.onDataChange()(editorData, errors, editor); });
+                });
+            });
+
+            // TODO: This is hideous, but it's necessary because all custom validators in
+            // JSON-Editor must be placed on the root JSONEditor object, which is a limitation of
+            // the library. In order to prevent custom validators from sticking around, we need to
+            // ensure that this gets cleaned up whenever a json-editor element is destroyed.  Note
+            // that this means that it is not possible to have two JsonEditor directives using
+            // different custom validators on the same page.  However, it ensures that directives in
+            // different pages don't pollute the global JSONEditor object.
+            element.on('$destroy', function() {
+                JsonEditorDefaults.customValidators.clear();
+            });
+        }
+    }
+
+    angular.module('json-editor')
+    .directive('jsonEditor', JsonEditor);
+
+})();

--- a/app/scripts/json-editor/module.js
+++ b/app/scripts/json-editor/module.js
@@ -1,0 +1,5 @@
+(function () {
+    'use strict';
+
+    angular.module('json-editor', []);
+})();

--- a/app/scripts/leaflet/leaflet-defaults-provider.js
+++ b/app/scripts/leaflet/leaflet-defaults-provider.js
@@ -1,0 +1,48 @@
+(function() {
+    'use strict';
+
+    /**
+     * Provides defaults for new maps created using the leafletMap directive.
+     *
+     * Defaults can be changed at config time via LeafletDefaults.setDefaults()
+     *
+    /* ngInject */
+    function LeafletDefaultsProvider() {
+        var svc = this;
+        var defaults = {
+            center: [0,0],
+            zoom: 1,
+            crs: L.CRS.EPSG3857
+        };
+
+        /**
+         * Update defaults by merging user-set defaults into defaults object
+         * @param {LeafletDefaults} newDefaults
+         */
+        svc.setDefaults = function (newDefaults) {
+            angular.merge(defaults, newDefaults);
+        };
+
+        svc.$get = LeafletDefaults;
+
+        /** Read-only wrapper around defaults */
+        /* ngInject */
+        function LeafletDefaults() {
+            var module = {
+                get: get
+            };
+            return module;
+
+            /**
+             * Return a copy of the current set of defaults
+             * @return {LeafletDefaults}
+             */
+            function get() {
+                return angular.extend({}, defaults);
+            }
+        }
+    }
+
+    angular.module('Leaflet')
+        .provider('LeafletDefaults', LeafletDefaultsProvider);
+})();

--- a/app/scripts/leaflet/leaflet-map-directive.js
+++ b/app/scripts/leaflet/leaflet-map-directive.js
@@ -1,0 +1,69 @@
+(function () {
+    'use strict';
+
+    /** Provides access to the leaflet map object instantiated by the directive */
+    /* ngInject */
+    function LeafletController($timeout, $q) {
+        var ctl = this;
+        var _map = null;
+        initialize();
+
+        function initialize() {
+            _map = $q.defer();
+
+            ctl.getMap = getMap;
+            ctl.setMap = setMap;
+        }
+
+        /**
+         * Get a promise reference to the map object created by the directive
+         * @return {Promise} Resolves with an L.map object
+         */
+        function getMap() {
+            return _map.promise;
+        }
+
+        /** Sets the map object for this controller. Call only once, on directive creation
+         * @param {L.map} map The L.map object to use on this controller.
+         */
+        function setMap(map) {
+            _map.resolve(map);
+
+            // This helps in some situations where the map isn't initially rendered correctly due
+            // to the container size being changed.
+            $timeout(function() {
+                map.invalidateSize();
+            }, 0);
+        }
+    }
+
+    /* ngInject */
+    function LeafletMap(LeafletDefaults) {
+        var module = {
+            restrict: 'A',
+            scope: {},
+            controller: 'LeafletController',
+            controllerAs: 'lf',
+            bindToController: true,
+            link: link
+        };
+        return module;
+
+        function link(scope, element, attrs, controller) {
+            var defaults = LeafletDefaults.get();
+            var map = new L.map(element[0], defaults);
+
+            // tell Leaflet where to find its images, or else it complains in production
+            // see: https://github.com/Leaflet/Leaflet/issues/766
+            if (!L.Icon.Default.imagePath) {
+                L.Icon.Default.imagePath = 'styles/images';
+            }
+
+            controller.setMap(map);
+        }
+    }
+
+    angular.module('Leaflet')
+        .controller('LeafletController', LeafletController)
+        .directive('leafletMap', LeafletMap);
+})();

--- a/app/scripts/leaflet/module.js
+++ b/app/scripts/leaflet/module.js
@@ -1,0 +1,5 @@
+(function () {
+    'use strict';
+
+    angular.module('Leaflet', []);
+})();

--- a/app/scripts/localization/date-picker-directive.js
+++ b/app/scripts/localization/date-picker-directive.js
@@ -1,0 +1,81 @@
+(function() {
+    'use strict';
+
+    /* ngInject */
+    /*
+     Scope args:
+         datetime {Date} - normal javascript datetime object
+         placeholder {string} - placeholder text for the text field
+         on-change {function} - function to call when datetime is changed
+     */
+    function DatePicker($timeout, DateLocalization) {
+        var internalCalendar;
+        var dateConfig;
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/localization/date-picker-partial.html',
+            scope: {
+                datetime: '=',
+                placeholder: '@',
+                onChange: '&'
+            },
+            link: link,
+            replace: true
+        };
+        return module;
+
+        function link(scope, element) {
+            dateConfig = DateLocalization.currentDateFormats();
+            internalCalendar = $.calendars.instance(
+                dateConfig.calendar, dateConfig.language
+            );
+            $.calendarsPicker.setDefaults($.calendarsPicker.regionalOptions['']);
+            var calendarOptions = angular.extend({
+                calendar: internalCalendar,
+                dateFormat: dateConfig.formats.numeric,
+                showAnim: '',
+                showTrigger:
+                '<span class="input-group-addon picker">' +
+                    '<span class="glyphicon glyphicon-calendar"></span>' +
+                '</span>'
+            }, $.calendarsPicker.regionalOptions[dateConfig.language]);
+
+            $(element)
+                .calendarsPicker(calendarOptions);
+            // Set up the selection callback on the next digest so that we don't
+            // do it on initialization.
+            $timeout(function() {
+                $(element).calendarsPicker(
+                    'option', 'onSelect', function(dates) {
+                        $timeout(function() {
+                            if (dates.length > 0) {
+                                updateDate(scope.datetime, dates[0]);
+                                scope.onChange();
+                            }
+                        });
+                    }
+                );
+            });
+
+            scope.$watch(function() {return scope.datetime;}, function(date) {
+                if (!date) {
+                    return;
+                }
+                $(element).calendarsPicker(
+                    'setDate', internalCalendar.fromJSDate(date)
+                );
+            });
+
+        }
+
+        function updateDate(date, cdate) {
+            var gregCDate = DateLocalization.convertToCalendar(cdate, 'gregorian', 'en');
+            var newDatetime = gregCDate._calendar.toJSDate(gregCDate);
+            if (newDatetime.valueOf() !== date.valueOf()) {
+                date.setTime(newDatetime.getTime());
+            }
+        }
+    }
+    angular.module('ase.localization')
+        .directive('azDatePicker', DatePicker);
+})();

--- a/app/scripts/localization/date-picker-partial.html
+++ b/app/scripts/localization/date-picker-partial.html
@@ -1,0 +1,3 @@
+<input type="text"
+       class="form-control"
+       placeholder="{{ placeholder }}">

--- a/app/scripts/localization/date-utils.js
+++ b/app/scripts/localization/date-utils.js
@@ -1,0 +1,933 @@
+(function() {
+    'use strict';
+
+    /* ngInject */
+    function DateLocalization(ASEConfig) {
+        var languageMap = {
+            'ar-sa': {
+                language: 'ar',
+                calendar: 'ummalqura',
+                formats: {
+                    'short': 'M Y',
+                    'longNoTime': 'd MM, Y',
+                    'long': 'd MM, Y',
+                    'numeric': 'dd/mm/yyyy'
+                }
+            },
+            'en-us': {
+                language: 'en',
+                calendar: 'gregorian',
+                formats: {
+                    'short': 'M Y',
+                    'longNoTime': 'MM d, Y',
+                    'long': 'MM d, Y',
+                    'numeric': 'm/dd/yyyy'
+                }
+            },
+            '': {
+                calendar: 'gregorian',
+                language: '',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'mm/dd/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'lt': {
+                calendar: 'gregorian',
+                language: 'lt',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'yyyy-mm-dd',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'ne': {
+                calendar: 'nepali',
+                language: 'lt',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'fr-CH': {
+                calendar: 'gregorian',
+                language: 'fr-CH',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'pl': {
+                calendar: 'gregorian',
+                language: 'pl',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'yyyy-mm-dd',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'eo': {
+                calendar: 'gregorian',
+                language: 'eo',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'sv': {
+                calendar: 'gregorian',
+                language: 'sv',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'yyyy-mm-dd',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'hu': {
+                calendar: 'gregorian',
+                language: 'hu',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'yyyy-mm-dd',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'af': {
+                calendar: 'gregorian',
+                language: 'af',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'ml': {
+                calendar: 'gregorian',
+                language: 'ml',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'bs': {
+                calendar: 'gregorian',
+                language: 'bs',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'no': {
+                calendar: 'gregorian',
+                language: 'no',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'hy': {
+                calendar: 'gregorian',
+                language: 'hy',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'zh-CN': {
+                calendar: 'gregorian',
+                language: 'zh-CN',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'yyyy-mm-dd',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'pa': {
+                calendar: 'nanakshahi',
+                language: 'pa',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd-mm-yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'am': {
+                calendar: 'ethiopian',
+                language: 'am',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'de-CH': {
+                calendar: 'gregorian',
+                language: 'de-CH',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'fi': {
+                calendar: 'gregorian',
+                language: 'fi',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'sr-SR': {
+                calendar: 'gregorian',
+                language: 'sr-SR',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'ar': {
+                calendar: 'islamic',
+                language: 'ar',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'ro': {
+                calendar: 'gregorian',
+                language: 'ro',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'hr': {
+                calendar: 'gregorian',
+                language: 'hr',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy.',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'bg': {
+                calendar: 'gregorian',
+                language: 'bg',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'mt': {
+                calendar: 'gregorian',
+                language: 'mt',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'en-AU': {
+                calendar: 'gregorian',
+                language: 'en-AU',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'he': {
+                calendar: 'hebrew',
+                language: 'he',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'id': {
+                calendar: 'gregorian',
+                language: 'id',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'tr': {
+                calendar: 'gregorian',
+                language: 'tr',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'ar-DZ': {
+                calendar: 'gregorian',
+                language: 'ar-DZ',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'km': {
+                calendar: 'gregorian',
+                language: 'km',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'ka': {
+                calendar: 'gregorian',
+                language: 'ka',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'eu': {
+                calendar: 'gregorian',
+                language: 'eu',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'yyyy/mm/dd',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'ko': {
+                calendar: 'gregorian',
+                language: 'ko',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'yyyy-mm-dd',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'fr': {
+                calendar: 'gregorian',
+                language: 'fr',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'mk': {
+                calendar: 'gregorian',
+                language: 'mk',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'de': {
+                calendar: 'gregorian',
+                language: 'de',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'ur': {
+                calendar: 'gregorian',
+                language: 'ur',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'hi-IN': {
+                calendar: 'gregorian',
+                language: 'hi-IN',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'cs': {
+                calendar: 'gregorian',
+                language: 'cs',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'nl-BE': {
+                calendar: 'gregorian',
+                language: 'nl-BE',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'es-AR': {
+                calendar: 'gregorian',
+                language: 'es-AR',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'th': {
+                calendar: 'gregorian',
+                language: 'th',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'me': {
+                calendar: 'gregorian',
+                language: 'me',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'zh-TW': {
+                calendar: 'gregorian',
+                language: 'zh-TW',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'yyyy/mm/dd',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'fo': {
+                calendar: 'gregorian',
+                language: 'fo',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd-mm-yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'pt-BR': {
+                calendar: 'gregorian',
+                language: 'pt-BR',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'it': {
+                calendar: 'gregorian',
+                language: 'it',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'sk': {
+                calendar: 'gregorian',
+                language: 'sk',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'et': {
+                calendar: 'gregorian',
+                language: 'et',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'ms': {
+                calendar: 'gregorian',
+                language: 'ms',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'es-PE': {
+                calendar: 'gregorian',
+                language: 'es-PE',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'lo': {
+                calendar: 'gregorian',
+                language: 'lo',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'es': {
+                calendar: 'gregorian',
+                language: 'es',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'nl': {
+                calendar: 'gregorian',
+                language: 'nl',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd-mm-yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'gl': {
+                calendar: 'gregorian',
+                language: 'gl',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'sr': {
+                calendar: 'gregorian',
+                language: 'sr',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'ta': {
+                calendar: 'gregorian',
+                language: 'ta',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'lv': {
+                calendar: 'gregorian',
+                language: 'lv',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd-mm-yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'rm': {
+                calendar: 'gregorian',
+                language: 'rm',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'da': {
+                calendar: 'gregorian',
+                language: 'da',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd-mm-yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'tt': {
+                calendar: 'gregorian',
+                language: 'tt',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'fa': {
+                calendar: 'persian',
+                language: 'fa',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'yyyy/mm/dd',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'uk': {
+                calendar: 'gregorian',
+                language: 'uk',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'ja': {
+                calendar: 'gregorian',
+                language: 'ja',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'yyyy/mm/dd',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'az': {
+                calendar: 'gregorian',
+                language: 'az',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'ca': {
+                calendar: 'gregorian',
+                language: 'ca',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'sq': {
+                calendar: 'gregorian',
+                language: 'sq',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'vi': {
+                calendar: 'gregorian',
+                language: 'vi',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'sl': {
+                calendar: 'gregorian',
+                language: 'sl',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'ru': {
+                calendar: 'gregorian',
+                language: 'ru',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd.mm.yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'bn': {
+                calendar: 'gregorian',
+                language: 'bn',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'en-GB': {
+                calendar: 'gregorian',
+                language: 'en-GB',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'gu': {
+                calendar: 'gregorian',
+                language: 'gu',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd-M-yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'zh-HK': {
+                calendar: 'gregorian',
+                language: 'zh-HK',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd-mm-yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'me-ME': {
+                calendar: 'gregorian',
+                language: 'me-ME',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'is': {
+                calendar: 'gregorian',
+                language: 'is',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'ar-EG': {
+                calendar: 'gregorian',
+                language: 'ar-EG',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'en-NZ': {
+                calendar: 'gregorian',
+                language: 'en-NZ',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'el': {
+                calendar: 'gregorian',
+                language: 'el',
+                formats: {
+                    'short': 'M Y',
+                    'numeric': 'dd/mm/yyyy',
+                    'long': 'd MM, Y',
+                    'longNoTime': 'd MM, Y'
+                }
+            },
+            'exclaim': {
+                language: 'en',
+                calendar: 'gregorian',
+                formats: {
+                    'short': 'M Y',
+                    'longNoTime': 'MM d, Y',
+                    'long': 'MM d,Y',
+                    'numeric': 'm/dd/yyyy'
+                }
+            }
+        };
+
+        var module = {
+            getLocalizedDateString: getLocalizedDateString,
+            currentDateFormats: currentDateFormats,
+            convertToCalendar: convertToCalendar,
+            convertNonTimezoneDate: convertNonTimezoneDate
+        };
+        return module;
+
+        /**
+         * Return the date formatting configuration for the currently selected interface language
+         * (Overrided to always provide English)
+         */
+        function currentDateFormats() {
+            return languageMap['en-us'];
+        }
+
+        /**
+         * Convert a CDate to a different calendar, identified by 'calendarName' and 'calendarLang'
+         * @param cDate {CDate}: CDate object to convert
+         * @param calendarName {string}: String identifying the name of the calendar to convert to
+         * @param calendarLang {string}: Two-character language code for the calendar
+         * @returns {CDate}: The date in the new calendar
+         *
+         */
+        function convertToCalendar(cDate, calendarName, calendarLang) {
+            return $.calendars.instance(calendarName, calendarLang)
+                .fromJD(cDate._calendar.toJD(cDate));
+        }
+
+        /*
+         * Get a localized date string for a date, using the LanguageState to
+         * choose the correct language. LanguageState is set using the language
+         * selector in the navbar
+         * NOTE: Currently overridden to only provide English.
+         *
+         * Args:
+         *     date (Date): the date to process
+         *     format (string): which string format to process the date into.
+         *                      Formats are defined per language in the languageMap
+         *     includeTime (string): Include the time in the returned string
+         *     excludeSeconds (string): Exclude seconds in the returned string
+         */
+        function getLocalizedDateString(date, format, includeTime, excludeSeconds) {
+            var conversion;
+            var localizedMoment = moment(date).tz(ASEConfig.localization.timeZone);
+            var localizedDate = new Date(localizedMoment.format('MMM DD YYYY'));
+            if (isNaN(localizedDate.getDate())) {
+                return '';
+            }
+            conversion = languageMap['en-us'];
+            var convertedDate = $.calendars.instance(conversion.calendar, conversion.language)
+                .fromJSDate(localizedDate);
+            var datestring = convertedDate.formatDate(conversion.formats[format], convertedDate);
+            if (includeTime) {
+                var hms = localizedMoment.format(excludeSeconds ? 'H:mm' : 'H:mm:ss');
+                datestring = datestring + ', ' + hms;
+            }
+            return datestring;
+        }
+
+        /**
+         * Since the date and time pickers rely on the browser's local timezone with
+         * no way to override, we need to modify the occurred datetime before it gets
+         * to the pickers. We want to show the datetime in the configured local tz,
+         * so we need to apply offsets for both the browser's tz and the configured
+         * local tz so it shows up as desired. This also needs to be undone before
+         * sending data over to the server when saving this request. This is a hack,
+         * but there's no clearly better way around it.
+         *
+         * @param {bool} reverse True if the fix is being reversed out of for saving purposes
+         */
+        function convertNonTimezoneDate(date, reverse) {
+            var dateDT = new Date(date);
+            var browserTZOffset = dateDT.getTimezoneOffset();
+            var configuredTZOffset = moment(dateDT).tz(ASEConfig.localization.timeZone)._offset;
+            // Note that the native js getTimezoneOffset returns the opposite of what
+            // you'd expect: i.e. EST which is UTC-5 gets returned as positive 5.
+            // The `moment` method of returning the offset would return this as a -5.
+            // Therefore if the browser tz is the same as the configured local tz,
+            // the following offset will cancel out and return zero.
+            var offset = (browserTZOffset + configuredTZOffset) * (reverse ? -1 : +1);
+
+            dateDT.setMinutes(dateDT.getMinutes() + offset);
+            return dateDT;
+        }
+    }
+
+    /* ngInject */
+    function LocalizeDateFilter(DateLocalization) {
+        function module(d, format, includeTime, excludeSeconds) {
+            return DateLocalization.getLocalizedDateString(
+                new Date(Date.parse(d)),
+                format,
+                includeTime,
+                excludeSeconds
+            );
+        }
+        return module;
+    }
+
+
+    angular.module('ase.localization')
+        .factory('DateLocalization', DateLocalization)
+        .filter('localizeRecordDate', LocalizeDateFilter);
+})();

--- a/app/scripts/localization/datetime-picker-directive.js
+++ b/app/scripts/localization/datetime-picker-directive.js
@@ -1,0 +1,66 @@
+(function() {
+    'use strict';
+
+    /* ngInject */
+    function DateTimePicker() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/localization/datetime-picker-partial.html',
+            controller: 'azDateTimePickerController',
+            controllerAs: 'ctl',
+            bindToController: true,
+            scope: {
+                datetime: '=',
+                onChange: '&'
+            },
+        };
+        return module;
+    }
+
+    /* ngInject */
+    function DateTimePickerController() {
+        var ctl = this;
+
+        ctl.$onInit = initialize();
+
+        function initialize() {
+            // We don't want minutes or seconds in the default datetime
+            var defaultDateTime = new Date();
+            defaultDateTime.setMinutes(0);
+            defaultDateTime.setSeconds(0);
+
+            ctl.updateDate = updateDate;
+            ctl.updateTime = updateTime;
+            ctl.date = defaultDateTime;
+            ctl.time = defaultDateTime;
+            updateDateTime();
+        }
+
+        // Time updates happen via ngChange, so they are within the digest cycle.
+        // Therefore we can just run updateDateTime and be done with it.
+        function updateTime() {
+            updateDateTime();
+        }
+
+        // Date updates happen via the onSelect event from the calendars-picker code,
+        // so these are outside the Angular digest cycle and need to be wrapped in
+        // a call to $apply.
+        function updateDate() {
+            updateDateTime();
+        }
+
+        function updateDateTime() {
+            var hours = ctl.time.getHours();
+            var minutes = ctl.time.getMinutes();
+            var newDatetime = new Date(ctl.date);
+            newDatetime.setHours(hours);
+            newDatetime.setMinutes(minutes);
+            ctl.datetime = newDatetime;
+            ctl.onChange();
+        }
+    }
+
+    angular.module('ase.localization')
+        .directive('azDateTimePicker', DateTimePicker)
+        .controller('azDateTimePickerController', DateTimePickerController);
+})();

--- a/app/scripts/localization/datetime-picker-partial.html
+++ b/app/scripts/localization/datetime-picker-partial.html
@@ -1,0 +1,17 @@
+<div class="locale-datetime-picker">
+  <div class="date-picker input-group">
+    <az-date-picker
+       class="date-picker"
+       datetime="ctl.date"
+       on-change="ctl.updateDate()"
+       placeholder="From ">
+  </div>
+  <div class="time-picker">
+    <timepicker
+        class="input-group"
+        ng-model="ctl.time"
+        show-meridian="false"
+        ng-change="ctl.updateTime()">
+    </timepicker>
+  </div>
+</div>

--- a/app/scripts/localization/module.js
+++ b/app/scripts/localization/module.js
@@ -1,0 +1,8 @@
+(function () {
+    'use strict';
+
+    angular.module('ase.localization', [
+        'ase.config'
+    ]);
+
+})();

--- a/app/scripts/map-layers/baselayers-service.js
+++ b/app/scripts/map-layers/baselayers-service.js
@@ -1,0 +1,58 @@
+(function () {
+    'use strict';
+
+    /* Service for sharing baselayer configuration.
+     */
+
+    /* ngInject */
+    function BaseLayersService() {
+
+        var module = {
+            streets: streets,
+            satellite: satellite,
+            baseLayers: baseLayers
+        };
+        return module;
+
+        function streets() {
+            var layer = new L.tileLayer(
+                'https://cartodb-basemaps-{s}.global.ssl.fastly.net/light_all/{z}/{x}/{y}.png',
+                {
+                    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://cartodb.com/attributions">CartoDB</a>',
+                    detectRetina: false,
+                    zIndex: 1
+                }
+            );
+            return layer;
+        }
+
+        function satellite() {
+            var layer = new L.tileLayer(
+                '//server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+                {
+                    attribution: 'Tiles &copy; Esri &mdash; Source: Esri, i-cubed, USDA, USGS, AEX, GeoEye, Getmapping, Aerogrid, IGN, IGP, UPR-EGP, and the GIS User Community',
+                    detectRetina: false,
+                    zIndex: 1
+                }            );
+            return layer;
+        }
+
+        function baseLayers() {
+            return [
+                {
+                    slugLabel: 'streets',
+                    label: 'Streets',
+                    layer: streets()
+                },
+                {
+                    slugLabel: 'satellite',
+                    label: 'Satellite',
+                    layer: satellite()
+                }
+            ];
+        }
+    }
+
+    angular.module('ase.map-layers')
+    .factory('BaseLayersService', BaseLayersService);
+})();

--- a/app/scripts/map-layers/module.js
+++ b/app/scripts/map-layers/module.js
@@ -1,0 +1,5 @@
+(function () {
+    'use strict';
+
+    angular.module('ase.map-layers', []);
+})();

--- a/app/scripts/navbar/module.js
+++ b/app/scripts/navbar/module.js
@@ -1,0 +1,10 @@
+(function () {
+    'use strict';
+
+    angular.module('ase.navbar', [
+        'ase.auth',
+        'ui.bootstrap',
+        'ui.router'
+    ]);
+
+})();

--- a/app/scripts/navbar/navbar-controller.js
+++ b/app/scripts/navbar/navbar-controller.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function ASENavbarController($rootScope, $scope, $state, AuthService) {
+        var ctl = this;
+
+        ctl.onLogoutButtonClicked = AuthService.logout;
+        ctl.authenticated = AuthService.isAuthenticated();
+
+        $rootScope.$on('$stateChangeSuccess', function() {
+            ctl.authenticated = AuthService.isAuthenticated();
+        });
+    }
+
+    angular.module('ase.navbar')
+    .controller('ASENavbarController', ASENavbarController);
+
+})();

--- a/app/scripts/navbar/navbar-directive.js
+++ b/app/scripts/navbar/navbar-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function ASENavbar() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/navbar/navbar-partial.html',
+            controller: 'ASENavbarController',
+            controllerAs: 'ctl',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.navbar')
+    .directive('aseNavbar', ASENavbar);
+
+})();

--- a/app/scripts/navbar/navbar-partial.html
+++ b/app/scripts/navbar/navbar-partial.html
@@ -1,0 +1,25 @@
+<header>
+    <nav class="navbar navbar-default">
+        <div class="container-fluid">
+            <!-- Brand and toggle get grouped for better mobile display -->
+            <div class="navbar-header">
+                <button type="button" class="navbar-toggle collapsed"
+                    data-toggle="collapse" data-target="#bs-example-navbar-collapse-1">
+                    <span class="sr-only">Toggle navigation</span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                    <span class="icon-bar"></span>
+                </button>
+                <a class="navbar-brand" href="#">Ashlar Space &amp; Time Database Builder v1.0</a>
+            </div>
+            <button ng-if="!ctl.authenticated" type="button" ng-click="ctl.onLoginButtonClicked()"
+                class="btn btn-default navbar-btn navbar-right">Sign in</button>
+            <button ng-if="ctl.authenticated" type="button" ng-click="ctl.onLogoutButtonClicked()"
+                class="btn btn-default navbar-btn navbar-right">Sign out</button>
+            <button ng-if="ctl.authenticated" type="button" ui-sref="settings.list"
+                class="btn btn-default navbar-btn navbar-right">System Settings</button>
+            <button ng-if="ctl.authenticated" type="button" ui-sref="usermgmt.list"
+                class="btn btn-default navbar-btn navbar-right">Manage Users</button>
+        </div><!-- /.container-fluid -->
+    </nav>
+</header>

--- a/app/scripts/notifications/README.md
+++ b/app/scripts/notifications/README.md
@@ -1,0 +1,18 @@
+# Notifications module
+
+Allows the broadcast and display of global notifications.
+
+## Usage
+
+1. Place a `<ase-notifications></ase-notifications` tag wherever you want notifications
+to appear. Remember that all notifications are global so this tag may display notifications
+from other parts of the app.
+2. Require the `Notifications` module and then call `Notifications.show(opts)` where opts
+is an Object with options for the new alert (info / warning / error status, timeout, etc.).
+Default values are generated in notifications-service.js for any missing options.
+
+## Limitations
+
+- Only one notification may be active at a time; subsequent notifications will override it.
+- Different notifications may not be sent to different instances of the directive; all
+notifications are global.

--- a/app/scripts/notifications/module.js
+++ b/app/scripts/notifications/module.js
@@ -1,0 +1,5 @@
+(function () {
+    'use strict';
+
+    angular.module('ase.notifications', ['ngSanitize']);
+})();

--- a/app/scripts/notifications/notifications-controller.js
+++ b/app/scripts/notifications/notifications-controller.js
@@ -1,0 +1,45 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function NotificationsController($scope, $timeout, Notifications) {
+        var ctl = this;
+        var alertTimeout = null;
+        initialize();
+
+        function initialize() {
+            ctl.alert = {};
+            ctl.alertHeight = 0;
+            ctl.hideAlert = hideAlert;
+
+            $scope.$on('ase.notifications.show', showAlert);
+
+            function showAlert(event, alert) {
+                ctl.alert = alert;
+                ctl.active = true;
+                if (alert.timeout) {
+                    alertTimeout = $timeout(hideAlert, alert.timeout);
+                }
+            }
+
+            function hideAlert() {
+                ctl.active = false;
+                if (alertTimeout) {
+                    $timeout.cancel(alertTimeout);
+                    alertTimeout = null;
+                    ctl.alert = null;
+                }
+                // clear notification in service as well
+                Notifications.hide();
+            }
+
+            if (Notifications.activeAlert()) {
+                showAlert(null, Notifications.activeAlert());
+            }
+        }
+    }
+
+    angular.module('ase.notifications')
+    .controller('NotificationsController', NotificationsController);
+
+})();

--- a/app/scripts/notifications/notifications-directive.js
+++ b/app/scripts/notifications/notifications-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function Notifications() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/notifications/notifications-partial.html',
+            controller: 'NotificationsController',
+            controllerAs: 'ntf',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.notifications')
+    .directive('aseNotifications', Notifications);
+
+})();

--- a/app/scripts/notifications/notifications-partial.html
+++ b/app/scripts/notifications/notifications-partial.html
@@ -1,0 +1,31 @@
+<div class="notifications alert" ng-hide="!ntf.active" ng-class="ntf.alert.displayClass">
+  <table ng-if="ntf.alert.text">
+    <tr>
+      <td><span class="glyphicon"
+          ng-class="ntf.alert.imageClass"
+          ng-if="ntf.alert.imageClass"></span></td>
+      <td>{{ ntf.alert.text }}</td>
+      <td><span class="glyphicon glyphicon-remove pull-right"
+          ng-if="ntf.alert.closeButton"
+          ng-click="ntf.hideAlert()"></span></td>
+    </tr>
+  </table>
+  <div ng-if="ntf.alert.html">
+    <span class="glyphicon pull-left"
+      ng-class="ntf.alert.imageClass"
+      ng-if="ntf.alert.imageClass">
+    </span>
+    <span class="glyphicon glyphicon-remove pull-right"
+      ng-if="ntf.alert.closeButton"
+      ng-click="ntf.hideAlert()">
+    </span>
+    <div class="container-fluid">
+      <div class="row">
+        <h4 class="text-center">{{ ntf.alert.header }}</h4>
+      </div>
+      <div class="row">
+        <div ng-bind-html="ntf.alert.html"></div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/scripts/notifications/notifications-service.js
+++ b/app/scripts/notifications/notifications-service.js
@@ -1,0 +1,61 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function Notifications($rootScope, $timeout) {
+
+        var timeoutId = null;
+        var active = null;
+
+        var module = {
+            hide: hide,
+            show: show,
+            activeAlert: activeAlert
+        };
+
+        return module;
+
+        /**
+         * Provide the currently active alert.
+         * Allows directives to display the active alert even if they miss the relevant event
+         * @return the currently active alert
+         */
+        function activeAlert() {
+            return active;
+        }
+
+        /**
+         * Hide a global notification
+         */
+        function hide() {
+            if (timeoutId) {
+                $timeout.cancel(timeoutId);
+                timeoutId = null;
+            }
+            active = null;
+        }
+
+        /**
+         * Show a global notification, overridding the defaults defined in the function
+         * @param  {object} options Override the defaults with this config
+         * @return Broadcasts ase.notifications.show on $rootScope
+         */
+        function show(options) {
+            var defaults = {
+                timeout: 0,
+                closeButton: true,
+                html: '',
+                text: '',
+                imageClass: 'glyphicon-warning-sign',
+                displayClass: 'alert-info'
+            };
+            var opts = angular.extend({}, defaults, options);
+            active = opts;
+            $rootScope.$broadcast('ase.notifications.show', opts);
+        }
+    }
+
+    angular.module('ase.notifications')
+    .factory('Notifications', Notifications);
+
+})();

--- a/app/scripts/resources/builderschemas-service.js
+++ b/app/scripts/resources/builderschemas-service.js
@@ -1,0 +1,22 @@
+/**
+ * Wrapper service for getting json schemas used for building new schemas via the json-editor.
+ * Currently the only builder schema is 'related' which is used for building related objects.
+ * These are stored as json files, because that's their native form, and it makes it easy to
+ * perform validation or test with using external tools (e.g. jdorn's forms).
+ */
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function BuilderSchemas($resource) {
+        return $resource('builder-schemas/:name.json', { name: '@name' }, {
+            get: {
+                method: 'GET'
+            }
+        });
+    }
+
+    angular.module('ase.resources')
+    .factory('BuilderSchemas', BuilderSchemas);
+
+})();

--- a/app/scripts/resources/geography-service.js
+++ b/app/scripts/resources/geography-service.js
@@ -1,0 +1,71 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function Geography($resource, $log, Upload, ASEConfig) {
+        var urlString = ASEConfig.api.hostname + '/api/boundaries/';
+        var res = $resource(urlString + ':uuid/ ', {uuid: '@uuid'}, {
+            query: {
+                method: 'GET',
+                transformResponse: function(data) { return angular.fromJson(data).results; },
+                isArray: true
+            },
+            update: {
+                method: 'PATCH',
+            }
+        });
+
+        /**
+         * Custom extension of geographies resource which uses ng-file-upload to send along the
+         *  shapefile which will be used to generate a geometry
+         *
+         * @param {array} files A list of files (most likely grabbed from a form) from which the
+         *                       head will be taken and sent across the wire
+         *
+         * @param {string} label The label which wil uniquely designate this geography
+         *
+         * @param {string} color The color for this geography
+         *
+         * @param {function} success A callback to be executed upon successful completion of this
+         *                            upload
+         *
+         */
+        res.create = function(files, label, color, success, error) {
+            if (files && files.length) {
+                var file = files[0];
+                Upload.upload({
+                    url: urlString,
+                    method: 'POST',
+                    fields: {'label': label,
+                             'color': color},
+                    file: file,
+                    fileFormDataName: 'source_file'
+                }).progress(function (evt) {
+                    var progressPercentage = parseInt(100.0 * evt.loaded / evt.total, 10);
+                    $log.debug('progress: ' + progressPercentage + '% ' + evt.config.file.name);
+                }).success(success).error(error);
+            }
+        };
+
+        /**
+         * Semantically route response status
+         *
+         * @param {integer} status Status code of an error response
+         * @return {string} Meaning of status code
+         */
+        res.errorMessage = function(status) {
+            var intension;
+            if (status === 409) {
+                 intension = 'Uniqueness violation - verify that your geography label is unique';
+            } else {
+                intension = 'Error - ensure that all fields have appropriate values';
+            }
+            return intension;
+        };
+
+        return res;
+    }
+
+    angular.module('ase.resources')
+      .factory('Geography', Geography);
+})();

--- a/app/scripts/resources/module.js
+++ b/app/scripts/resources/module.js
@@ -1,0 +1,15 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function ResourceConfig($resourceProvider) {
+        $resourceProvider.defaults.stripTrailingSlashes = false;
+    }
+
+    angular.module('ase.resources', [
+        'ngResource',
+        'ase.config',
+        'ngFileUpload'
+    ]).config(ResourceConfig);
+
+})();

--- a/app/scripts/resources/records-service.js
+++ b/app/scripts/resources/records-service.js
@@ -1,0 +1,53 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function Records($resource, ASEConfig) {
+        var baseUrl = ASEConfig.api.hostname + '/api/records/';
+        return $resource(baseUrl + ':id/', {
+            id: '@uuid',
+            archived: 'False' // Note: a regular 'false' boolean doesn't filter properly in DRF
+        }, {
+            create: {
+                method: 'POST'
+            },
+            get: {
+                method: 'GET'
+            },
+            query: {
+                method: 'GET',
+                transformResponse: function(data) { return angular.fromJson(data).results; },
+                isArray: true
+            },
+            update: {
+                method: 'PATCH'
+            },
+            toddow: {
+                url: baseUrl + 'toddow/',
+                method: 'GET',
+                isArray: true
+            },
+            stepwise: {
+                url: baseUrl + 'stepwise/',
+                method: 'GET',
+                isArray: true
+            },
+            recentCounts: {
+                method: 'GET',
+                url: baseUrl + 'recent_counts/'
+            },
+            report: {
+                url: baseUrl + 'crosstabs/',
+                method: 'GET'
+            },
+            socialCosts: {
+                url: baseUrl + 'costs/',
+                method: 'GET'
+            }
+        });
+    }
+
+    angular.module('ase.resources')
+    .factory('Records', Records);
+
+})();

--- a/app/scripts/resources/recordschemas-service.js
+++ b/app/scripts/resources/recordschemas-service.js
@@ -1,0 +1,29 @@
+
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RecordSchemas($resource, ASEConfig) {
+        return $resource(ASEConfig.api.hostname + '/api/recordschemas/:id/',
+                         {id: '@uuid', limit: 'all'}, {
+            create: {
+                method: 'POST'
+            },
+            get: {
+                method: 'GET'
+            },
+            query: {
+                method: 'GET',
+                transformResponse: function(data) { return angular.fromJson(data).results; },
+                isArray: true
+            },
+            update: {
+                method: 'PATCH'
+            }
+        });
+    }
+
+    angular.module('ase.resources')
+    .factory('RecordSchemas', RecordSchemas);
+
+})();

--- a/app/scripts/resources/recordtypes-service.js
+++ b/app/scripts/resources/recordtypes-service.js
@@ -1,0 +1,28 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RecordTypes($resource, ASEConfig) {
+        var url = ASEConfig.api.hostname + '/api/recordtypes/:id/';
+        return $resource(url, {id: '@uuid', limit: 'all'}, {
+            create: {
+                method: 'POST'
+            },
+            get: {
+                method: 'GET'
+            },
+            query: {
+                method: 'GET',
+                transformResponse: function(data) { return angular.fromJson(data).results; },
+                isArray: true
+            },
+            update: {
+                method: 'PATCH'
+            }
+        });
+    }
+
+    angular.module('ase.resources')
+    .factory('RecordTypes', RecordTypes);
+
+})();

--- a/app/scripts/schemas/module.js
+++ b/app/scripts/schemas/module.js
@@ -1,0 +1,7 @@
+
+(function () {
+    'use strict';
+
+    angular.module('ase.schemas', []);
+
+})();

--- a/app/scripts/schemas/schemas-service.js
+++ b/app/scripts/schemas/schemas-service.js
@@ -1,0 +1,461 @@
+/**
+ * Responsible for schema serialization and deserialization
+ *
+ * In order to add a new FieldType, you need to do the following:
+ * 1. Add a new type key and toProperty (serialization) function to FieldTypes
+ * 2. Add a new field definition object to the json schema (builder-schemas/related.json).
+ *    Ensure your newly created object has a matching fieldType attribute, which must be unique.
+ *    This is so that when we serialize this object to data and back, we can remember what
+ *    type of field it is.
+ *
+ * @return {[type]} [description]
+ */
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function Schemas() {
+        // Static properties which cannot be changed when editing a schema
+        var systemOnlyProperties = { _localId: true };
+
+        var module = {
+            JsonObject: jsonObject,
+            FieldTypes: {
+                'text': { // Text field
+                    toProperty: function(fieldData) {
+                        var textProperty = {
+                            type: 'string',
+                            format: fieldData.textOptions
+                        };
+
+                        // Required text fields also need a minLength field for validation
+                        if (fieldData.isRequired) {
+                            textProperty.minLength = 1;
+                        }
+
+                        return textProperty;
+                    }
+                },
+                'number': { // Number field
+                    toProperty: function(fieldData) {
+                        var numberProperty = {
+                            type: 'number',
+                            minimum: undefined,
+                            maximum: undefined
+                        };
+
+                        assignMinMax(fieldData, numberProperty);
+
+                        return numberProperty;
+                    }
+                },
+//                'integer': { // Number --> integer
+//                    toProperty: function(fieldData) {
+//                        var integerProperty = {
+//                            type: 'integer',
+//                            minimum: undefined,
+//                            maximum: undefined
+//                        };
+//
+//                        assignMinMax(fieldData, integerProperty);
+//
+//                        return integerProperty;
+//                    }
+//                },
+                'selectlist': { // Select list
+                    toProperty: function(fieldData) {
+                        if (fieldData.displayType === 'checkbox') {
+                            return {
+                                type: 'array',
+                                format: 'checkbox',
+                                uniqueItems: true,
+                                items: {
+                                    type: 'string',
+                                    enum: fieldData.fieldOptions
+                                }
+                            };
+                        }
+                        return {
+                            type: 'string',
+                            enum: fieldData.fieldOptions,
+                            displayType: fieldData.displayType
+                        };
+                    }
+                },
+                'image': { // Image uploader
+                    toProperty: function() {
+                        return {
+                            type: 'string',
+                            media: {
+                                binaryEncoding: 'base64',
+                                type: 'image/jpeg'
+                            }
+                        };
+                    }
+                },
+                'reference': { // Local reference
+                    /** Creates a property that uses the 'watch' feature of JSON-Editor for info
+                     * @param {object} fieldData The schema form field data to convert into this property
+                     * @param {number} index The index of the form data in the form
+                     * @param {object} allData Data from all fields in the schema form
+                     * @param {object} currentSchema The current prior to the changes being generated
+                     * @param {string} definitionName The definition to store this in
+                     * This function is complex because it looks at the current schema to figure out
+                     * the names of fields that exist on the type that is being referred to so that
+                     * the reference dropdown can be auto-populated with meaningful information.
+                     */
+
+                    toProperty: function(fieldData, index, allData, currentSchema) {
+                        var displayProperties = [];
+                        // Switch depending on whether fieldData.referenceTarget == definitionName
+                        // Note that self-referential targets are disabled via a validation
+                        // function at the moment because they cause JSON-Editor to break. However,
+                        // I didn't realize that until after I wrote this code, so leaving it here
+                        // in a comment in case we need to re-enable this later.
+                        /*
+                        if (fieldData.referenceTarget === definitionName) { // Self-referential
+                            // Need to use what the data is going to be, not what it was
+                            _.each(allData, function(fieldData) {
+                                if (fieldData.fieldType !== 'reference') {
+                                    displayProperties.push('{{item.' + fieldData.fieldTitle + '}}');
+                                }
+                            });
+                            displayProperties = displayProperties.slice(0,3);
+                        */
+                        //} else { // Referencing a different related info type
+                        var visibleProperties = _.filter(
+                            _.keys(currentSchema.definitions[fieldData.referenceTarget].properties),
+                            function(propName) { return !systemOnlyProperties[propName]; }
+                        );
+                        visibleProperties.sort();
+                        // Grab at most the first three property names
+                        for (var i = 0; i < 3 && i < visibleProperties.length; i++) {
+                            displayProperties.push('{{item.' + visibleProperties[i] + '}}');
+                        }
+                        //}
+                        return {
+                            type: 'string',
+                            watch: {
+                                target: fieldData.referenceTarget
+                            },
+                            enumSource: [{
+                                    source: 'target',
+                                    title: displayProperties.join(' '),
+                                    value: '{{item._localId}}'
+                            }]
+                        };
+                    }
+                }
+            },
+            addVersion4Declaration: addVersion4Declaration,
+            addRelatedContentFields: addRelatedContentFields,
+            validateSchemaFormData: validateSchemaFormData,
+            definitionFromSchemaFormData: definitionFromSchemaFormData,
+            schemaFormDataFromDefinition: schemaFormDataFromDefinition,
+            generateFieldName: generateFieldName
+        };
+        return module;
+
+        function assignMinMax(fieldData, property) {
+            /** If neither minimum nor maximum is specified,
+             * they're left null, which helps json-editor's
+             * validation out by not setting limits.
+             */
+
+            if (fieldData.minimum < fieldData.maximum) {
+                property.minimum = fieldData.minimum;
+                property.maximum = fieldData.maximum;
+            } else if (fieldData.minimum && fieldData.maximum === 0) {
+                property.minimum = fieldData.minimum;
+            } else if (fieldData.maximum && fieldData.minimum === 0) {
+                property.maximum = fieldData.maximum;
+            }
+        }
+
+        /**
+         * Convert field titles into field names that are valid java identifiers
+         * by doing the following:
+         *
+         *  - strip out control characters
+         *  - prepend name with driver to ensure whitelisted words are excluded
+         *  - convert to camel case
+         *
+         * @param {string} "Example Field Name"
+         * @return {string} "driverExampleFieldName_udb234"
+         */
+        function generateFieldName(str) {
+            // Remove control characters with regular expression
+            var strippedStr = 'driver ' + str.replace(/[\x00-\x1F\x7F-\x9F.,\/#!$%\^&\*;:{}=\-_`~()]/g, '');
+            // http://stackoverflow.com/questions/2970525/converting-any-string-into-camel-case
+            return strippedStr.replace(/(?:^\w|[A-Z]|\b\w|\s+)/g, function(match, index) {
+                if (+match === 0) {
+                    return '';
+                }
+                return index === 0 ? match.toLowerCase() : match.toUpperCase();
+            });
+        }
+
+        /**
+         * Converts part of the output of a Schema Entry Form (data about fields)
+         * into a snippet designed to be inserted into the 'properties' key of a Data Form Schema
+         * which would be used for data entry / editing. Does not perform validation.
+         * @param {object} fieldData The value of one Schema Entry Form field, specifying required,
+         *      searchable, possible values, etc.
+         * @param {number} index The index of this field in its form
+         * @return {object} A snippet designed to be inserted into the 'properties' of a Data Form
+         *      Schema
+         */
+        // TODO: This monolithic function isn't great; investigate more modular options
+        // (likewise in the deserializing function below)
+        function _propertyFromSchemaFieldData(fieldData, index, allData, currentSchema,
+                definitionName) {
+            var propertyDefinition;
+            if (fieldData.fieldType !== 'integer') {
+                propertyDefinition = module.FieldTypes[fieldData.fieldType].toProperty(fieldData,
+                        index,
+                        allData,
+                        currentSchema,
+                        definitionName
+                    );
+            } else {
+                propertyDefinition = module.FieldTypes.number.toProperty(fieldData,
+                        index,
+                        allData,
+                        currentSchema,
+                        definitionName
+                );
+                propertyDefinition.type = 'integer';
+            }
+
+            // Set the common properties
+            propertyDefinition.isSearchable = fieldData.isSearchable;
+
+            // Include the fieldType to make deserialization easier; without this we have to guess
+            // based on other properties.
+            propertyDefinition.fieldType = fieldData.fieldType;
+
+            // Insert the array index into the 'propertyOrder' key; this is a custom key
+            // defined by JSON-Editor to allow specification of property ordering, which is not
+            // supported by JSON-Schema (yet)
+            propertyDefinition.propertyOrder = index;
+
+            return propertyDefinition;
+        }
+
+        /**
+         * Converts the output of a Schema Entry Form into a sub-schema designed to be
+         * inserted into the 'definitions' key of a Data Form Schema. Does not perform
+         * validation.
+         * @param {array} formData The values in the Schema Form, defining the fields in
+         *      this Data Form Schema
+         * @param {object} existingSchema The full schema into which this definition will be
+         *      inserted. Used for populating referential data fields.
+         * @return {object} The serialized JSON-Schema snippet
+         */
+        function definitionFromSchemaFormData(formData, currentSchema, definitionName) {
+            var definition = {
+                properties: {},
+                type: 'object'
+            };
+            definition = addRelatedContentFields(definition);
+            // properties
+            _.each(formData, function(fieldData, index, allData) {
+                definition.properties[fieldData.fieldTitle] = _propertyFromSchemaFieldData(
+                    fieldData,
+                    index,
+                    allData,
+                    currentSchema,
+                    definitionName
+                );
+            });
+
+            // required
+            // A list containing the titles of properties which are required.
+            var required = _.pluck(
+                _.filter(formData, function(fieldData) {
+                    return fieldData.isRequired;
+                }), 'fieldTitle');
+
+            // All definitions start with a required "_localId" property
+            definition.required = definition.required.concat(required);
+
+            return definition;
+        }
+
+        /**
+         * Inverse of the above; converts a sub-schema into a JSON-Schema that will allow
+         * JSON-Editor to generate the correct form elements for editing the fields in the schema.
+         * @param {object} definition The sub-schema to convert into fields
+         * @return {array} Form schema to allow editing the fields in definition
+         */
+        function schemaFormDataFromDefinition(definition) {
+            var formData = [];
+
+            _.each(definition.properties, function(schemaField, title) {
+                if (systemOnlyProperties[title]) {
+                    // Don't include in schema editor form
+                } else {
+                    var fieldData = {
+                        fieldTitle: title
+                    };
+                    // checkboxes work a little differently
+                    if (schemaField.format === 'checkbox') {
+                        fieldData.fieldType = 'selectlist';
+                        fieldData.displayType = 'checkbox';
+                        _.each(schemaField, function(value, key) {
+                            switch(key) {
+                                case 'items':
+                                    fieldData.fieldOptions = value.enum;
+                                    break;
+                                case 'type':
+                                case 'format':
+                                case 'uniqueItems':
+                                    break;
+                                default:
+                                    fieldData[key] = value;
+                            }
+                        });
+                    } else {
+                        // Iterate over schema keys and take the appropriate action
+                        _.each(schemaField, function(value, key) {
+                            switch(key) {
+                                case 'enum':
+                                    fieldData.fieldOptions = value;
+                                    break;
+                                case 'format':
+                                    fieldData.textOptions = value;
+                                    break;
+                                case 'type': // This is the JSON-Schema 'type', which is not used here.
+                                    break;
+                                case 'media': // Also not used
+                                    break;
+                                case 'watch':
+                                    fieldData.referenceTarget = value.target;
+                                    break;
+                                case 'enumSource': // Companion to 'watch', but not used here
+                                    break;
+                                default:
+                                    fieldData[key] = value;
+                            }
+                        });
+                    }
+
+                    // Handle required fields, which are stored outside the field info
+                    var indexInRequired = _.findIndex(definition.required, function(item) {
+                        return item === title;
+                    });
+                    if (indexInRequired >= 0) { // I.e., found title in required: [...]
+                        fieldData.isRequired = true;
+                    } else {
+                        fieldData.isRequired = false;
+                    }
+
+                    formData.push(fieldData);
+                }
+            });
+            // Order the resulting array by the propertyOrder field so that fields appear in
+            // the same order in which they'll appear during data entry. JSON-Editor only applies
+            // the propertyOrder keyword if it appears *inside* a property. If it appears *as* a
+            // property, it won't have any effect, so we need to do the sorting ourselves.
+            formData.sort(function(a, b) {
+                if (a.propertyOrder < b.propertyOrder) {
+                    return -1;
+                }
+                if (a.propertyOrder > b.propertyOrder) {
+                    return 1;
+                }
+                return 0;
+            });
+            return formData;
+        }
+
+        /**
+         * Validate that a Schema Entry Form has valid data; currently validates that there are no
+         * duplicate fieldTitles because this is currently not easily done in native JSON-Schema
+         * (the uniqueItems keyword doesn't allow specifying which fields should be used to
+         * determine uniqueness).
+         * @param {object} formData The values in a Schema Form
+         * @return {array} List of errors, if any
+         *
+         * NOTE: For field-level validation, JSON-Editor provides a custom_validators hook that
+         * should be used (see json-editor-defaults.js).
+         * TODO: See if we can restructure our code to allow custom validators that need access to
+         * the full form data. This is currently difficult to do because json-editor doesn't provide
+         * access to this information to the validators by default, but it provides better UX
+         * because the errors will be attached to the fields to which they apply.
+         */
+        function validateSchemaFormData(formData) {
+            var errors = [];
+            var titleCounts = _.countBy(formData, function(fieldData) {
+                return fieldData.fieldTitle;
+            });
+            _.forEach(titleCounts, function(count, title) {
+                if (count > 1) {
+                    errors.push({ 'message': 'Invalid schema: The field title "' + title +
+                        '" is used more than once.'
+                    });
+                }
+            });
+            return errors;
+        }
+
+        /**
+         * Adds a $schema keyword to an object; this declares that the object is JSON-Schema v4
+         * @param {object} schema Object to which the declaration should be added
+         * @return {object} The schema with the $schema keyword added, pointing to Draft 4
+         */
+        function addVersion4Declaration(schema) {
+            return angular.extend(schema, { $schema: 'http://json-schema.org/draft-04/schema#' });
+        }
+
+        /**
+         * Adds a _localId field to a schema's properties that can store a UUID
+         * @param {object} schema Object to which the declaration should be added
+         * @return {object} The schema with a _localId property added
+         */
+        function addRelatedContentFields(schema) {
+            schema.properties = angular.extend(schema.properties, {
+                _localId: { // A special field allowing relationships between objects within a record
+                    // A pattern for a UUID field is helpfully supplied at
+                    // http://json-schema.org/example2.html
+                    type: 'string',
+                    pattern: '^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$',
+                    options: {
+                        hidden: true
+                    }
+                }
+            });
+            if (schema.required) {
+                schema.required = schema.required.concat(['_localId']);
+            } else {
+                schema.required = ['_localId'];
+            }
+            return schema;
+        }
+
+        /**
+         * Creates a new blank object for use in a JSON-Schema
+         * @param {object} Object to extend; default {}
+         * @return {object} A blank object for use in a JSON-Schema
+         */
+        function jsonObject(newObject) {
+            newObject = newObject || {};
+            return angular.extend({}, {
+                /* jshint camelcase: false */
+                type: 'object',
+                title: '',
+                plural_title: '',
+                description: '',
+                properties: {},
+                definitions: {}
+                /* jshint camelcase: true */
+            }, newObject);
+        }
+
+
+    }
+
+    angular.module('ase.schemas')
+    .service('Schemas', Schemas);
+
+})();

--- a/app/scripts/userdata/module.js
+++ b/app/scripts/userdata/module.js
@@ -1,0 +1,7 @@
+(function () {
+'use strict';
+
+    angular.module('ase.userdata', [
+        'ase.config'
+      ]);
+})();

--- a/app/scripts/userdata/user-service.js
+++ b/app/scripts/userdata/user-service.js
@@ -1,0 +1,126 @@
+(function() {
+    'use strict';
+
+    /**
+     * @ngInject
+     */
+    function UserService ($log, $resource, $q, ASEConfig) {
+
+        var tmpToken = '';
+
+        var User = $resource(ASEConfig.api.hostname + '/api/users/:id/', {id: '@id', limit: 'all'}, {
+            'create': {
+                method: 'POST',
+                url: ASEConfig.api.hostname + '/api/users/'
+            },
+            'delete': {
+                method: 'DELETE',
+                url: ASEConfig.api.hostname + '/api/users/:id/'
+            },
+            'update': {
+                method: 'PATCH',
+                url: ASEConfig.api.hostname + '/api/users/:id/'
+            },
+            'changePassword' : {
+                method: 'POST',
+                url: ASEConfig.api.hostname + '/api/users/:id/change_password/'
+            },
+            'resetPassword' : {
+                method: 'POST',
+                url: ASEConfig.api.hostname + '/api/users/:id/reset_password/'
+            },
+            'query': {
+                method: 'GET',
+                transformResponse: function(data) { return angular.fromJson(data).results; },
+                isArray: true
+            },
+            'queryWithTmpHeader': {
+                method: 'GET',
+                headers: {
+                    'Authorization': function() {
+                        // use a temporarily set token
+                        return 'Token ' + tmpToken;
+                    }
+                }
+            }
+        }, {
+            cache: true,
+            stripTrailingSlashes: false
+        });
+
+        var module = {
+            User: User,
+            canWriteRecords: canWriteRecords,
+            getUser: getUser,
+            isAdmin: isAdmin
+        };
+        return module;
+
+        function getUser(userId) {
+            var dfd = $q.defer();
+            module.User.get({id: userId}, function (user) {
+                // append attribute to response to indicate if user is an admin or not
+                user.isAdmin = userBelongsToAdmin(user);
+                dfd.resolve(user);
+            });
+            return dfd.promise;
+        }
+
+        // Check whether user has write access
+        function canWriteRecords(userId, token) {
+            tmpToken = token;
+            var dfd = $q.defer();
+            module.User.queryWithTmpHeader({id: userId}, function (user) {
+                if (user && user.groups) {
+                    // admin or analyst can write records
+                    if (userBelongsToAdmin(user) ||
+                        user.groups.indexOf(ASEConfig.api.groups.readWrite) > -1) {
+
+                        dfd.resolve(true);
+                    } else {
+                        dfd.resolve(false);
+                    }
+                } else {
+                    dfd.resolve(false);
+                }
+                tmpToken = '';
+            });
+
+            return dfd.promise;
+        }
+
+        // Check whether user is an admin or not before logging them in (for the editor)
+        function isAdmin(userId, token) {
+            tmpToken = token;
+            var dfd = $q.defer();
+            module.User.queryWithTmpHeader({id: userId}, function (user) {
+                $log.debug('user service got user to test:');
+                $log.debug(user);
+                $log.debug('with groups:');
+                $log.debug(user.groups);
+                if (userBelongsToAdmin(user)) {
+                    $log.debug('have admin in user service');
+                    dfd.resolve(true);
+                } else {
+                    dfd.resolve(false);
+                }
+                tmpToken = '';
+            });
+
+            return dfd.promise;
+        }
+
+        // hepler to check for admin group membership
+        function userBelongsToAdmin(user) {
+            if (user && user.groups && user.groups.indexOf(ASEConfig.api.groups.admin) > -1) {
+                return true;
+            } else {
+                return false;
+            }
+        }
+    }
+
+    angular.module('ase.userdata').factory('UserService', UserService);
+
+})();
+

--- a/app/scripts/utils/module.js
+++ b/app/scripts/utils/module.js
@@ -1,0 +1,6 @@
+
+(function () {
+    'use strict';
+
+    angular.module('ase.utils', []);
+})();

--- a/app/scripts/utils/utils-service.js
+++ b/app/scripts/utils/utils-service.js
@@ -1,0 +1,44 @@
+
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function Utils () {
+        var module = {
+            buildErrorHtml: buildErrorHtml
+        };
+        return module;
+
+        /**
+         * Build descriptive list of fields with sub-lists of field errors.
+         *
+         * @param error Object DRF error response
+         * @return String HTML to display in notification
+         */
+        function buildErrorHtml(error) {
+            var errorHtml = '';
+            // get back dict of {fieldName: [Array of errors]} from DRF CRUD endpoints
+            if (error.data) {
+                errorHtml += '<ul>';
+                angular.forEach(error.data, function(fieldErrors, fieldName) {
+                    // list point for each field
+                    errorHtml += '<li>' + fieldName + ':';
+                    if (fieldErrors.length) {
+                        errorHtml += '<ul>';
+                        // sub-list with points for each field error
+                        fieldErrors.forEach(function(err) {
+                            errorHtml += '<li>' + err + '</li>';
+                        });
+                        errorHtml += '</ul>';
+                    }
+                    errorHtml += '</ul>';
+                });
+            }
+            return errorHtml;
+        }
+    }
+
+    angular.module('ase.utils')
+    .factory('Utils', Utils);
+
+})();

--- a/app/scripts/views/login/auth-controller.js
+++ b/app/scripts/views/login/auth-controller.js
@@ -1,0 +1,54 @@
+(function() {
+    'use strict';
+
+    /**
+     * @ngInject
+     */
+    function AuthController ($scope, $state, $window, AuthService, ASEConfig) {
+
+        $scope.auth = {};
+
+        $scope.alerts = [];
+        $scope.addAlert = function(alertObject) {
+            $scope.alerts.push(alertObject);
+        };
+        $scope.closeAlert = function(index) {
+            $scope.alerts.splice(index, 1);
+        };
+
+        $scope.authenticate = function() {
+            $scope.alerts = [];
+            $scope.authenticated = AuthService.authenticate($scope.auth, true);
+            $scope.authenticated.then(function(result) {
+                if (result.isAuthenticated) {
+                    // redirect to editor main page, with a full page reload,
+                    // to pick up the newly set credentials
+                    $window.location.href = '/editor/';
+                } else {
+                    handleError(result);
+                }
+            }, function (result) {
+                handleError(result);
+            });
+        };
+
+        $scope.sso = function(client) {
+            $window.location.href = [ASEConfig.api.hostname,
+                '/openid/openid/',
+                client,
+                '?next=/editor/'].join('');
+        };
+
+        var handleError = function (result) {
+            $scope.auth.failure = true;
+            var msg = result.error || (result.status + ': Unknown Error.');
+            $scope.addAlert({
+                type: 'danger',
+                msg: msg
+            });
+        };
+    }
+
+    angular.module('ase.views.login').controller('AuthController', AuthController);
+
+})();

--- a/app/scripts/views/login/login-partial.html
+++ b/app/scripts/views/login/login-partial.html
@@ -1,0 +1,31 @@
+<div class="container loginmodal">
+    <form ng-submit="authenticate()" autocomplete="off">
+      <div class="row">
+        <div class="col-12">
+          <h3>Log In to Ashlar</h3>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-12 loginmodal-field">
+          <div class="form-group" ng-class="{true: 'login-field-error', false: ''}[auth.failure]">
+            <label for="username">Username:</label>
+            <input type="text" id="username" ng-model="auth.username" />
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-12 loginmodal-field">
+          <div class="form-group" ng-class="{true: 'login-field-error', false: ''}[auth.failure]">
+            <label for="password">Password:</label>
+            <input type="password" id="password" ng-model="auth.password" />
+          </div>
+        </div>
+      </div>
+      <div class="row">
+        <div class="col-12 loginmodal-field">
+          <button type="submit" class="button button-primary btn-block">Login</button>
+        </div>
+      </div>
+    </form>
+    <alert ng-repeat="alert in alerts" type="alert.type">{{alert.msg}}</alert>
+</div>

--- a/app/scripts/views/login/module.js
+++ b/app/scripts/views/login/module.js
@@ -1,0 +1,27 @@
+(function () {
+    'use strict';
+
+    /**
+     * @ngInject
+     */
+    function StateConfig($stateProvider) {
+        $stateProvider.state('login', {
+            url: '/login',
+            templateUrl: 'scripts/views/login/login-partial.html',
+            controller: 'AuthController',
+        });
+    }
+
+    /**
+     * @ngdoc overview
+     * @name driver.views
+     * @description
+     * # driver
+     */
+    angular
+      .module('ase.views.login', [
+        'ui.router',
+        'ase.auth'
+      ]).config(StateConfig);
+
+})();

--- a/app/scripts/views/record/add-edit-controller.js
+++ b/app/scripts/views/record/add-edit-controller.js
@@ -1,0 +1,467 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RecordAddEditController($log, $scope, $state, $stateParams, $window, $q, $timeout,
+                                     uuid, AuthService, JsonEditorDefaults,
+                                     Notifications, Records, RecordSchemas,
+                                     RecordTypes, DateLocalization) {
+        var ctl = this;
+        var editorData = null;
+        var bbox = null;
+
+        ctl.$onInit = initialize();
+
+        // Initialize for either adding or editing, depending on recorduuid being supplied
+        function initialize() {
+            ctl.combineOccurredFromDateAndTime = combineOccurredFromDateAndTime;
+            ctl.combineOccurredToDateAndTime = combineOccurredToDateAndTime;
+            ctl.fixOccurredDTForPickers = fixOccurredDTForPickers;
+            ctl.goBack = goBack;
+            ctl.onDataChange = onDataChange;
+            ctl.onDeleteClicked = onDeleteClicked;
+            ctl.onSaveClicked = onSaveClicked;
+            ctl.onGeomChanged = onGeomChanged;
+
+            ctl.userCanWrite = AuthService.hasWriteAccess();
+
+            // This state attribute will be true when adding secondary records. When editing,
+            // this will be set when the record type is loaded.
+            ctl.isSecondary = $state.current.secondary;
+
+            ctl.constantFieldErrors = null;
+            ctl.geom = {
+                lat: null,
+                lng: null
+            };
+
+            ctl.occurredFromDate = new Date();
+            ctl.occurredToDate = new Date();
+            ctl.occurredFromTime = new Date();
+            ctl.occurredToTime = new Date();
+
+            $scope.$on('ase.views.record:marker-moved', function(event, data) {
+                // update location when map marker set
+                $scope.$apply(function() {
+                    ctl.geom.lat = data[1];
+                    ctl.geom.lng = data[0];
+                });
+
+                // update whether we have all constant fields or not
+                constantFieldsValidationErrors();
+            });
+
+            $scope.$on('ase.views.record:map-moved', function(event, data) {
+                bbox = data;
+            });
+
+            // If there's a record, load it first then get its schema.
+            var schemaPromise;
+            if ($stateParams.recorduuid) {
+                schemaPromise = loadRecord().then(loadRecordSchema);
+            } else if ($stateParams.recordtype) {
+                schemaPromise = loadRecordSchema($stateParams.recordtype);
+                // Besides being friendly, setting a default works around this bug:
+                // https://github.com/angular-ui/bootstrap/issues/1114
+                ctl.occurredFrom = ctl.occuredTo = new Date();
+            }
+
+            schemaPromise.then(function () {
+                onSchemaReady();
+            });
+
+            $scope.$on('$destroy', function() {
+                // let map know to destroy its state
+                $scope.$emit('ase.views.record:close');
+            });
+
+        }
+
+        function initDateTimePickers() {
+            ctl.occurredFromDate = new Date(ctl.occurredFrom);
+            ctl.occurredFromTime = new Date(ctl.occurredFrom);
+            ctl.occurredToDate = new Date(ctl.occurredTo);
+            ctl.occurredToTime = new Date(ctl.occurredTo);
+        }
+
+        function combineOccurredFromDateAndTime() {
+            var hours = ctl.occurredFromTime.getHours();
+            var minutes = ctl.occurredFromTime.getMinutes();
+            var newDatetime = new Date(ctl.occurredFromDate);
+            newDatetime.setHours(hours);
+            newDatetime.setMinutes(minutes);
+            ctl.occurredFrom = newDatetime;
+            constantFieldsValidationErrors();
+        }
+
+        function combineOccurredToDateAndTime() {
+            if (ctl.occurredToTime) {
+                var hours = ctl.occurredToTime.getHours();
+                var minutes = ctl.occurredToTime.getMinutes();
+                var newDatetime = new Date(ctl.occurredToDate);
+                newDatetime.setHours(hours);
+                newDatetime.setMinutes(minutes);
+                ctl.occurredTo = newDatetime;
+            }
+            constantFieldsValidationErrors();
+        }
+
+        // tell embed-map-directive to update marker location
+        function onGeomChanged(recenter) {
+            if (ctl.geom.lat && ctl.geom.lng) {
+                $scope.$emit('ase.views.record:location-selected', ctl.geom, recenter);
+            }
+
+            // update whether all constant fields are present
+            constantFieldsValidationErrors();
+        }
+
+        /* Apply timezone fixes to the picker components */
+        function fixOccurredDTForPickers(reverse) {
+            ctl.occurredFrom = DateLocalization.convertNonTimezoneDate(ctl.occurredFrom, reverse);
+            if (ctl.occurredTo) {
+                ctl.occurredTo = DateLocalization.convertNonTimezoneDate(ctl.occurredTo, reverse);
+            }
+        }
+
+        // Helper for loading the record -- only used when in edit mode
+        function loadRecord() {
+            return Records.get({ id: $stateParams.recorduuid })
+                .$promise.then(function(record) {
+                    ctl.record = record;
+
+                    /* jshint camelcase: false */
+                    ctl.occurredFrom = ctl.record.occurred_from;
+                    ctl.occurredTo = ctl.record.occurred_to;
+                    /* jshint camelcase: true */
+
+                    // Prep the occurred_from datetime for use with pickers
+                    fixOccurredDTForPickers(false);
+
+                    initDateTimePickers();
+                    // set lat/lng array into bind-able object
+                    ctl.geom.lat = ctl.record.geom.coordinates[1];
+                    ctl.geom.lng = ctl.record.geom.coordinates[0];
+
+                    // notify map
+                    onGeomChanged(false);
+                });
+        }
+
+        /* Loads the right schema:
+         * - If there's a record, loads the latest schema for the record's type
+         *   (edit mode)
+         * - Otherwise, checks for a record type that can be used to find a schema
+         *   (add mode)
+         * - If no record type loads (e.g. if someone has navigated to the view
+         *   improperly), sets an error and returns a rejected promise.
+         */
+        function loadRecordSchema(recordTypeUuid) {
+            var typePromise,
+                recordLoaded;
+            if (ctl.record) {
+                // If there's a record loaded, get its schema
+                typePromise = RecordTypes.query({ record: ctl.record.uuid }).$promise;
+                recordLoaded = true;
+
+            } else if (typeof(recordTypeUuid !== 'undefined')) {
+                // The user is adding a new record, so retrieve the schema for
+                // the record type that they selected
+                typePromise = RecordTypes.get({ id: recordTypeUuid }).$promise;
+                recordLoaded = false;
+
+            } else {
+                ctl.error = 'Unable to load record schema: no Record or RecordType specified.';
+                return $q.reject(ctl.error);
+            }
+
+            return typePromise.then(function (result) {
+                // TODO: Remove secondary logic. For now, default to false.
+                ctl.isSecondary = false;
+
+                // The `get` and `query` endpoints return different data types;
+                // switch the request based on which endpoint was used
+                var recordType = (recordLoaded === true) ? result[0] : result;
+
+                if (recordType) {
+                    ctl.recordType = recordType;
+                    /* jshint camelcase: false */
+                    return RecordSchemas.get({ id: ctl.recordType.current_schema }).$promise
+                    /* jshint camelcase: true */
+                        .then(function(recordSchema) { ctl.recordSchema = recordSchema; });
+                } else {
+                    ctl.error = 'Unable to load record schema.';
+                    return $q.reject(ctl.error);
+                }
+            });
+        }
+
+        /*
+         * Ensures each object in the record contains all appropriate properties available
+         * from the schema. This is a workaround for a problem with json-editor. When it
+         * saves an item it removes any properties that aren't set, and then when the
+         * item is loaded into the editor again, any properties that aren't set aren't
+         * rendered even though they exist within the schema. Thus, in the course of
+         * editing, if anything is ever removed, or an enum is set to empty, it will never
+         * be able to be selected again. This works around those problems.
+         */
+        function fixEmptyFields() {
+            if (!ctl.record) {
+                return;
+            }
+
+            _.forEach(ctl.recordSchema.schema.definitions, function(definition, defKey) {
+                _.forEach(definition.properties, function(property, propKey) {
+                    if (!ctl.record.data.hasOwnProperty(defKey)) {
+                        ctl.record.data[defKey] = null;
+                    }
+                    var data = ctl.record.data[defKey];
+
+                    _.forEach(definition.multiple ? data : [data], function(item) {
+                        if (item && !item.hasOwnProperty(propKey)) {
+                            item[propKey] = null;
+                        }
+                    });
+                });
+            });
+        }
+
+        function onSchemaReady() {
+            fixEmptyFields();
+
+            /* jshint camelcase: false */
+            ctl.editor = {
+                id: 'new-record-editor',
+                options: {
+                    schema: ctl.recordSchema.schema,
+                    disable_edit_json: true,
+                    disable_properties: true,
+                    disable_array_delete_all_rows: true,
+                    disable_array_delete_last_row: true,
+                    disable_array_reorder: true,
+                    collapsed: true,
+                    theme: 'bootstrap3',
+                    iconlib: 'bootstrap3',
+                    show_errors: 'change',
+                    no_additional_properties: true,
+                    startval: ctl.record ? ctl.record.data : null
+                },
+                errors: []
+            };
+            /* jshint camelcase: true */
+        }
+
+        /*
+         * Recursively sets all empty _localId fields to a new uuid
+         * @param {object} obj The object to recursively search
+         * @return {bool} True if any changes were made
+         */
+        function setLocalIds(obj) {
+            var changed = false;
+            _.each(obj, function(propertyValue, propertyName) {
+                if (propertyName === '_localId' && !propertyValue) {
+                    obj._localId = uuid.v4();
+                    changed = true;
+                } else if (propertyValue instanceof Array) {
+                    _.each(propertyValue, function(item) {
+                        changed = changed || setLocalIds(item);
+                    });
+                } else if (propertyValue instanceof Object) {
+                    changed = changed || setLocalIds(propertyValue);
+                }
+            });
+            return changed;
+        }
+
+        function onDataChange(newData, validationErrors, editor) {
+
+            // Fill in all empty _localId fields
+            if (setLocalIds(newData)) {
+                editor.setValue(newData);
+                return;
+            }
+
+            // Update editorData reference: used later during save
+            editorData = newData;
+            ctl.editor.errors = validationErrors;
+        }
+
+        /* Validate the constant value fields, which are not handled by json-editor.
+         *
+         * @returns {String} error message, which is empty if there are no errors
+         */
+        function constantFieldsValidationErrors() {
+            var required = {
+                'latitude': ctl.geom.lat,
+                'longitude': ctl.geom.lng,
+                'occurred': ctl.occurredFrom
+            };
+
+            ctl.constantFieldErrors = {};
+            angular.forEach(required, function(value, fieldName) {
+                if (!value) {
+                    // message formatted to match errors from json-editor
+                    ctl.constantFieldErrors[fieldName] = fieldName + ': Value required';
+                }
+            });
+
+            if (ctl.isSecondary && ctl.occurredFrom && ctl.occurredTo &&
+                    ctl.occurredFrom > ctl.occurredTo) {
+                ctl.constantFieldErrors.occurredTo = 'End date cannot be before start date.';
+            }
+
+            // make field errors falsy if empty, for partial to check easily
+            if (Object.keys(ctl.constantFieldErrors).length === 0) {
+                ctl.constantFieldErrors = null;
+                return '';
+            } else {
+                var errors = _.map(ctl.constantFieldErrors, function(message) {
+                    return '<p>' + message + '</p>';
+                });
+                return errors.join('');
+            }
+        }
+
+        function goBack() {
+            var prevPage = $window.location.href;
+            $window.history.back();
+
+            // If going back to the previous page didn't result in any change, then it means
+            // this was opened by the edit link which targets a new window. In this case we
+            // want the window to be closed.
+            // There is not a reliable way to check if this was navigated to via a normal link
+            // or a new window link (the referrer value isn't useful due to the way angular loads),
+            // so this is just checking to see if going back in history changed anything, and if
+            // not it closes the window.
+            $timeout(function() {
+                if ($window.location.href === prevPage) {
+                    $window.close();
+                }
+            }, 200);
+        }
+
+        function onDeleteClicked() {
+            if ($window.confirm('Do you really want to delete? This cannot be undone.')) {
+                var patchData = {
+                    archived: true,
+                    uuid: ctl.record.uuid
+                };
+
+                Records.update(patchData, function (record) {
+                    $log.debug('Deleted record with uuid: ', record.uuid);
+                    $state.go('record.list', { recordtype: ctl.recordType.uuid });
+                }, function (error) {
+                    $log.debug('Error while deleting record:', error);
+                    showErrorNotification([
+                        '<p>',
+                        'Error creating record',
+                        '</p><p>',
+                        error.status,
+                        ': ',
+                        error.statusText,
+                        '</p>'
+                    ].join(''));
+                });
+            }
+        }
+
+        function onSaveClicked() {
+            var validationErrorMessage = constantFieldsValidationErrors();
+
+            if (ctl.editor.errors.length > 0) {
+                $log.debug('json-editor errors on save:', ctl.editor.errors);
+                // Errors array has objects each with message, path, and property,
+                // where path looks like 'root.Thing Details.Stuff',
+                // property like 'minLength'
+                // and message like 'Value required'.
+                // Show error as 'Stuff: Value required'
+                ctl.editor.errors.forEach(function(err) {
+                    // strip the field name from the end of the path
+                    var fieldName = err.path.substring(err.path.lastIndexOf('.') + 1);
+                    validationErrorMessage += ['<p>',
+                        fieldName,
+                        ': ',
+                        err.message,
+                        '</p>'
+                    ].join('');
+                });
+                showErrorNotification(validationErrorMessage);
+                return;
+            } else if (validationErrorMessage.length > 0) {
+                // have constant field errors only
+                showErrorNotification(validationErrorMessage);
+                return;
+            }
+
+            // If there is already a record, set the new editorData and update, else create one
+            var saveMethod = null;
+            var dataToSave = null;
+
+            // If editing a primary record (where we don't ask for 'to' date) or if 'to' date is
+            // blank, set it to be the same as 'from' date.
+            if (!ctl.isSecondary || !ctl.occurredTo) {
+                ctl.occurredTo = ctl.occurredFrom;
+            }
+
+            // Reverse the date and time picker timezone fix to get back to the actual correct time
+            fixOccurredDTForPickers(true);
+
+            /* jshint camelcase: false */
+            if (ctl.record && ctl.record.geom) {
+                // set back coordinates
+                ctl.record.geom.coordinates = [ctl.geom.lng, ctl.geom.lat];
+                ctl.record.occurred_from = ctl.occurredFrom;
+                ctl.record.occurred_to = ctl.occurredTo;
+
+                saveMethod = 'update';
+                dataToSave = ctl.record;
+                dataToSave.data = editorData;
+            } else {
+                saveMethod = 'create';
+                dataToSave = {
+                    data: editorData,
+                    schema: ctl.recordSchema.uuid,
+
+                    // constant fields
+                    geom: 'POINT(' + ctl.geom.lng + ' ' + ctl.geom.lat + ')',
+                    occurred_from: ctl.occurredFrom,
+                    occurred_to: ctl.occurredTo
+                };
+            }
+            /* jshint camelcase: true */
+
+            Records[saveMethod](dataToSave, function (record) {
+                $log.debug('Saved record with uuid: ', record.uuid);
+                if (ctl.isSecondary) {
+                    $state.go('map');
+                } else {
+                    $state.go('record.list', { recordtype: ctl.recordType.uuid });
+                }
+            }, function (error) {
+                $log.debug('Error while creating record:', error);
+                var errorMessage = '<p>Error creating record</p><p>';
+                if (error.data) {
+                    errorMessage += _.flatten(_.values(error.data)).join('<br>');
+                } else {
+                    errorMessage += (error.status + ': ' + error.statusText);
+                }
+                errorMessage += '</p>';
+                showErrorNotification(errorMessage);
+            });
+        }
+
+        // helper to display errors when form fails to save
+        function showErrorNotification(message) {
+            Notifications.show({
+                displayClass: 'alert-danger',
+                header: 'Record Not Saved',
+                html: message
+            });
+        }
+
+    }
+
+    angular.module('ase.views.record')
+    .controller('RecordAddEditController', RecordAddEditController);
+
+})();

--- a/app/scripts/views/record/add-edit-directive.js
+++ b/app/scripts/views/record/add-edit-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RecordAddEdit() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/record/add-edit-partial.html',
+            controller: 'RecordAddEditController',
+            controllerAs: 'ctl',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.record')
+    .directive('recordAddEdit', RecordAddEdit);
+
+})();

--- a/app/scripts/views/record/add-edit-partial.html
+++ b/app/scripts/views/record/add-edit-partial.html
@@ -1,0 +1,137 @@
+<div class="json-editor-form form-area no-filterbar" ng-if="ctl.userCanWrite && !ctl.error">
+    <div class="container">
+        <div class="row">
+            <div class="col-sm-10 col-sm-offset-2">
+                <div class="form-area-heading">
+                    <h2>New {{ ::ctl.recordType.label }} Record</h2>
+                    <div class="content-border"></div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-9" ng-class="{ 'col-sm-push-3': isRightToLeft }">
+                        <ase-notifications></ase-notifications>
+                        <div class="constant-fields">
+                            <div class="well">
+                                <h3>{{ ::ctl.recordType.label }} Location & Time</h3>
+                                <div class="row">
+                                    <div class="col-md-12">
+                                        <div class="map" leaflet-map embed-map editable="true"></div>
+                                    </div>
+                                </div>
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        <div class="form-group"
+                                            ng-class="ctl.constantFieldErrors.latitude ? 'has-error' : ''">
+                                            <label class="control-label required">Latitude</label>
+                                            <input type="number" class="form-control"
+                                                ng-change="ctl.onGeomChanged(false)" ng-model="ctl.geom.lat">
+                                            <p ng-if="ctl.constantFieldErrors.latitude"
+                                                class="help-block errormsg">Value required.</p>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <div class="form-group"
+                                            ng-class="ctl.constantFieldErrors.longitude ? 'has-error' : ''">
+                                            <label class="control-label required">Longitude</label>
+                                            <input type="number" class="form-control"
+                                                ng-change="ctl.onGeomChanged(false)" ng-model="ctl.geom.lng">
+                                            <p ng-if="ctl.constantFieldErrors.longitude"
+                                                class="help-block errormsg">Value required.</p>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        <div class="form-group date-picker"
+                                            ng-class="ctl.constantFieldErrors.occurred ? 'has-error' : ''">
+                                            <label class="control-label required">
+                                                Occured From
+                                            </label>
+                                            <div class="input-group">
+                                                <az-date-picker
+                                                    id="occurred-from-datepicker"
+                                                    datetime="ctl.occurredFromDate"
+                                                    on-change="ctl.combineOccurredFromDateAndTime()"
+                                                    placeholder="From">
+                                                </az-date-picker>
+                                            </div>
+                                            <p ng-if="ctl.constantFieldErrors.occurred"
+                                                class="help-block errormsg">{{ctl.constantFieldErrors.occurred}}</p>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <div class="form-group time-picker">
+                                            <timepicker
+                                                class="input-group"
+                                                ng-model="ctl.occurredFromTime"
+                                                show-meridian="false"
+                                                ng-change="ctl.combineOccurredFromDateAndTime()">
+                                            </timepicker>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                <div class="row">
+                                    <div class="col-md-6">
+                                        <div class="form-group date-picker"
+                                            ng-class="ctl.constantFieldErrors.occurredTo ? 'has-error' : ''">
+                                            <label class="control-label">Occurred To</label>
+                                            <div class="input-group">
+                                                <az-date-picker
+                                                    id="occurred-to-datepicker"
+                                                    datetime="ctl.occurredToDate"
+                                                    on-change="ctl.combineOccurredToDateAndTime()"
+                                                    placeholder="To">
+                                                </az-date-picker>
+                                            </div>
+                                            <p ng-if="ctl.constantFieldErrors.occurredTo"
+                                                class="help-block errormsg">{{ctl.constantFieldErrors.occurredTo}}</p>
+                                        </div>
+                                    </div>
+                                    <div class="col-md-6">
+                                        <div class="form-group time-picker">
+                                            <div class="input-group"
+                                                timepicker
+                                                ng-model="ctl.occurredToTime"
+                                                ng-change="ctl.combineOccurredToDateAndTime()">
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <json-editor editor-id="{{ ctl.editor.id }}"
+                                    options="ctl.editor.options"
+                                    on-data-change="ctl.onDataChange"
+                                    class="form-area-body">
+                        </json-editor>
+                    </div>
+                    <div class="col-sm-3" ng-class="{ 'col-sm-pull-9': isRightToLeft }">
+                        <div class="save-area">
+                            <button type="button" class="btn btn-primary btn-block"
+                                ng-disabled="ctl.editor.errors.length > 0 || ctl.constantFieldErrors"
+                                ng-click="ctl.onSaveClicked()">
+                                Save {{ ::ctl.recordType.label }}
+                            </button>
+                            <button type="button" class="btn btn-warning btn-block" ng-if="ctl.record"
+                                ng-click="ctl.onDeleteClicked()">
+                                Delete {{ ::ctl.recordType.label }}
+                            </button>
+                            <button type="button" class="btn btn-default btn-block" ng-click="ctl.goBack()">
+                                Cancel
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="form-area no-filterbar" ng-if="::!ctl.userCanWrite">
+    <!-- Shouldn't get here, but have a message to display, just in case -->
+    <h2>Current user does not have access to write records.</h2>
+</div>
+<div class="form-area no-filterbar" ng-if="::ctl.error">
+    <!-- Shouldn't get here, but have a message to display, just in case -->
+    <h2>{{ctl.error}}</h2>
+</div>

--- a/app/scripts/views/record/details-controller.js
+++ b/app/scripts/views/record/details-controller.js
@@ -1,0 +1,41 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RecordDetailsController($stateParams, Records, RecordTypes, RecordSchemas) {
+        var ctl = this;
+        initialize();
+
+        function initialize() {
+            loadRecord().then(loadRecordSchema);
+        }
+
+        function loadRecord () {
+            return Records.get({ id: $stateParams.recorduuid })
+                .$promise.then(function(record) {
+                    ctl.record = record;
+                });
+        }
+
+        function loadRecordSchema() {
+            return RecordTypes.query({ record: $stateParams.recorduuid }).$promise
+                .then(function (result) {
+                    ctl.recordType = result[0];
+
+                    // TODO: Figure out whether we can remove all "secondary
+                    // types" logic. Till then, set everything to secondary.
+                    ctl.isSecondary = true;
+                    ctl.record.isSecondary = ctl.isSecondary;
+
+                    /* jshint camelcase: false */
+                    return RecordSchemas.get({ id: ctl.recordType.current_schema }).$promise
+                        .then(function(recordSchema) { ctl.recordSchema = recordSchema; });
+                    /* jshint camelcase: true */
+                });
+        }
+    }
+
+    angular.module('ase.views.record')
+    .controller('RecordDetailsController', RecordDetailsController);
+
+})();

--- a/app/scripts/views/record/details-directive.js
+++ b/app/scripts/views/record/details-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RecordDetails() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/record/details-partial.html',
+            controller: 'RecordDetailsController',
+            controllerAs: 'ctl',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.record')
+    .directive('recordDetails', RecordDetails);
+
+})();

--- a/app/scripts/views/record/details-modal-controller.js
+++ b/app/scripts/views/record/details-modal-controller.js
@@ -1,0 +1,29 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RecordDetailsModalController($modalInstance, record, recordType,
+                                          recordSchema, userCanWrite) {
+        var ctl = this;
+        initialize();
+
+        function initialize() {
+            ctl.record = record;
+            ctl.recordType = recordType;
+            ctl.recordSchema = recordSchema;
+            ctl.userCanWrite = userCanWrite;
+
+            ctl.close = function () {
+                $modalInstance.close();
+            };
+
+            // TODO: Figure out if we can remove secondary type logic. Till
+            // then, set all records to secondary.
+            ctl.record.isSecondary = true;
+        }
+    }
+
+    angular.module('ase.views.record')
+    .controller('RecordDetailsModalController', RecordDetailsModalController);
+
+})();

--- a/app/scripts/views/record/details-modal-partial.html
+++ b/app/scripts/views/record/details-modal-partial.html
@@ -1,0 +1,33 @@
+<div class="incident-report modal-content">
+    <div class="modal-content">
+        <div class="close" ng-click="modal.close()">
+            &times;
+        </div>
+        <div class="report-header">
+            <h3 class="modal-title">
+                <small ng-if="modal.userCanWrite" class="pull-right">
+                    <a ui-sref="record.edit({ recorduuid: modal.record.uuid })" target="_blank">
+                        <span class="glyphicon glyphicon-share"></span> Edit
+                    </a>
+                </small>
+                <small class="pull-right">
+                    <a ui-sref="record.details({ recorduuid: modal.record.uuid })" target="_blank">
+                        <span class="glyphicon glyphicon-share"></span> View
+                    </a>
+                </small>
+                {{ modal.recordType.label }} Details
+            </h3>
+        </div>
+        <ase-details-tabs
+            class="modal-body"
+            record-schema="modal.recordSchema"
+            record="modal.record"
+            user-can-write="modal.userCanWrite">
+        </ase-details-tabs>
+        <div class="modal-footer">
+            <button class="btn btn-primary" ng-click="modal.close()">
+                Close
+            </button>
+        </div>
+    </div>
+</div>

--- a/app/scripts/views/record/details-partial.html
+++ b/app/scripts/views/record/details-partial.html
@@ -1,0 +1,14 @@
+<div class="form-area no-filterbar">
+    <div class="col-sm-8 col-sm-offset-2">
+        <ase-notifications></ase-notifications>
+        <div class="form-area-heading">
+            <h2>{{ ::ctl.recordType.label }} Details</h2>
+            <div class="content-border"></div>
+            <ase-details-tabs
+                 record-schema="ctl.recordSchema"
+                 record="ctl.record"
+                 ng-if="ctl.record && ctl.recordSchema">
+            </ase-details-tabs>
+        </div>
+    </div>
+</div>

--- a/app/scripts/views/record/embed-map-controller.js
+++ b/app/scripts/views/record/embed-map-controller.js
@@ -1,0 +1,136 @@
+(function () {
+    'use strict';
+
+    // Default level to zoom to when a location is selected or a marker is dropped
+    var zoomInLevel = 17;
+
+    /* ngInject */
+    function EmbedMapController($log, $timeout, $scope, $rootScope, BaseLayersService) {
+        var dblClickTimeout = null;
+        var ctl = this;
+
+        ctl.isEditable = false;
+        ctl.map = null;
+        ctl.locationMarker = null;
+        /*
+         * Initialize map and listen for click events, if editable.
+         *
+         * @param {Object} leafletMap Map object returned from intialized leaflet directive
+         * @param {Boolean} isEditable If set to true, update and broadcast marker location on click
+         * @param {Double} lat If set, initial latitude for marker
+         * @param {Double} lng If set, initial longitude for marker
+         */
+        ctl.setUpMap = function(leafletMap, isEditable, lat, lng) {
+            ctl.map = leafletMap;
+            ctl.isEditable = !!isEditable;
+
+            var baseMaps = BaseLayersService.baseLayers();
+
+            if(!ctl.layerSwitcher){
+                ctl.layerSwitcher = L.control.layers(
+                    _.zipObject(_.map(baseMaps, 'label'), _.map(baseMaps, 'layer'))
+                );
+                ctl.layerSwitcher.addTo(ctl.map);
+            }
+
+            // set the base layer
+            var baseLayer = baseMaps[0];
+            ctl.map.addLayer(baseLayer.layer);
+
+            if (ctl.isEditable) {
+                ctl.map.on('click', handleClick);
+                ctl.map.on('moveend', function(e) {
+                    broadcastBBox(e.target.getBounds());
+                });
+            }
+
+            // If a location was passed in, center and zoom to that.
+            if (lat && lng) {
+                setMarker(L.latLng(lat, lng));
+            }
+        };
+
+        /** Handle a click; need to do a bit of work here to prevent moving the marker on
+         * double-click. This has the unfortunate side effect of causing the marker placement to
+         * be slightly delayed.
+         */
+        function handleClick(e) {
+            if (dblClickTimeout) {
+                $timeout.cancel(dblClickTimeout);
+                dblClickTimeout = null;
+            } else {
+                dblClickTimeout = $timeout(function() {
+                  broadcastCoordinates(e.latlng);
+                  setMarker(e.latlng);
+                  dblClickTimeout = null;
+                }, 300);
+            }
+        }
+
+        /** Set marker location, or create marker at location if it does not exist yet.
+         *
+         * @param {Object} latlng Leaflet LatLng object with coordinates for marker
+         */
+        function setMarker(latlng) {
+            if (ctl.locationMarker) {
+                ctl.locationMarker.setLatLng(latlng);
+            } else {
+                ctl.locationMarker = new L.marker(latlng, {draggable: ctl.isEditable}).addTo(ctl.map);
+
+                if (ctl.isEditable) {
+                    ctl.locationMarker.on('dragend', function() {
+                        broadcastCoordinates(ctl.locationMarker.getLatLng());
+                    });
+                }
+
+                // pan/zoom to marker on add
+                ctl.map.setView(latlng, zoomInLevel, {animate: true});
+            }
+        }
+
+        /** Tell add-edit-controller.js about bbox
+         *
+         * @param {Object} bbox Leaflet LatLngBounds object with map's bounds
+         */
+        function broadcastBBox(bbox) {
+            $rootScope.$broadcast('ase.views.record:map-moved', [bbox.getWest(), bbox.getNorth(),
+                                                                    bbox.getEast(), bbox.getSouth()]);
+        }
+
+        /** Tell add-edit-controller.js when marker point set.
+         *
+         * @param {Object} latlng Leaflet LatLng object with marker's coordinates
+         */
+        function broadcastCoordinates(latlng) {
+            if (!ctl.isEditable) {
+                $log.error('Attempting to broadcast marker coordinates on non-editable map');
+                return;
+            }
+            $rootScope.$broadcast('ase.views.record:marker-moved', [latlng.lng, latlng.lat]);
+        }
+
+        $rootScope.$on('ase.views.record:location-selected', function(event, data, recenter) {
+            if (!ctl.map) {
+                return;
+            }
+
+            var latlng = L.latLng(data.lat, data.lng);
+            setMarker(latlng);
+            if (recenter) {
+                ctl.map.setView(latlng, zoomInLevel, {animate: true});
+            }
+        });
+
+        // destroy map state when record is closed
+        $scope.$on('ase.views.record:close', function() {
+            ctl.map = null;
+            ctl.locationMarker = null;
+        });
+
+        return ctl;
+    }
+
+    angular.module('ase.views.record')
+    .controller('embedMapController', EmbedMapController);
+
+})();

--- a/app/scripts/views/record/embed-map-directive.js
+++ b/app/scripts/views/record/embed-map-directive.js
@@ -1,0 +1,30 @@
+(function () {
+    'use strict';
+
+    function embedMap() {
+
+        var module = {
+            restrict: 'A',
+            scope: false,
+            replace: false,
+            controller: 'embedMapController',
+            require: ['leafletMap', 'embed-map'],
+            link: link
+        };
+        return module;
+
+        function link(linkScope, element, attrs, controllers) {
+
+            var leafletController = controllers[0];
+            var controller = controllers[1];
+
+            leafletController.getMap().then(function(map) {
+                controller.setUpMap(map, attrs.editable, attrs.lat, attrs.lng);
+            });
+        }
+    }
+
+    angular.module('ase.views.record')
+        .directive('embedMap', embedMap);
+
+})();

--- a/app/scripts/views/record/list-controller.js
+++ b/app/scripts/views/record/list-controller.js
@@ -1,0 +1,147 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RecordListController($scope, $rootScope, $log, $modal, $state, AuthService,
+                                  Notifications, RecordSchemas, Records, ASEConfig,
+                                  $stateParams, $q, RecordTypes) {
+        var ctl = this;
+        ctl.currentOffset = 0;
+        ctl.numRecordsPerPage = ASEConfig.record.limit;
+        ctl.maxDataColumns = 4; // Max number of dynamic data columns to show
+        ctl.getPreviousRecords = getPreviousRecords;
+        ctl.getNextRecords = getNextRecords;
+        ctl.showDetailsModal = showDetailsModal;
+        ctl.isInitialized = false;
+        ctl.userCanWrite = false;
+
+        init();
+
+        function init() {
+            ctl.isInitialized = false;
+            ctl.userCanWrite = AuthService.hasWriteAccess();
+
+            if (typeof($stateParams.recordtype !== 'undefined')) {
+                var recordTypeUuid = $stateParams.recordtype;
+                loadRecordSchema(recordTypeUuid);
+            } else {
+                ctl.error = 'Unable to load record schema: no RecordType specified.';
+                return $q.reject(ctl.error);
+            }
+        }
+
+        function loadRecordSchema(recordTypeUuid) {
+            RecordTypes.get({ id: recordTypeUuid }).$promise.then(function (result) {
+                var recordType = result;
+                if (recordType) {
+                    ctl.recordType = recordType;
+                    /* jshint camelcase: false */
+                    return RecordSchemas.get({ id: ctl.recordType.current_schema }).$promise
+                    /* jshint camelcase: true */
+                        .then(function(recordSchema) { ctl.recordSchema = recordSchema; })
+                        .then(onSchemaLoaded)
+                        .then(loadRecords);
+                } else {
+                    ctl.error = 'Unable to load record schema.';
+                    return $q.reject(ctl.error);
+                }
+            });
+        }
+
+        /*
+         * Loads a page of records from the API
+         * @param {int} offset Optional offset value, relative to current offset, used
+         *                     for pulling paginated results. May be positive or negative.
+         * @return {promise} Promise to load records
+         */
+        function loadRecords(offset) {
+            ctl.loadingRecords = true;
+            var newOffset;
+            if (offset) {
+                newOffset = ctl.currentOffset + offset;
+            } else {
+                newOffset = 0;
+            }
+
+            var params = {
+                offset: newOffset,
+                limit: ASEConfig.record.limit,
+                /* jshint camelcase: false */
+                record_type: ctl.recordType.uuid
+                /* jshint camelcase: true */
+            };
+
+            Records.get(params).$promise
+            .then(function(records) {
+                ctl.records = records;
+                ctl.currentOffset = newOffset;
+            }).finally(function() {
+                ctl.loadingRecords = false;
+            });
+        }
+
+        function onSchemaLoaded() {
+            var detailsDefinitions = _.filter(ctl.recordSchema.schema.definitions,
+                function(val, key) {
+                    if (key.indexOf('Details') > -1) {
+                        // keep the actual field name
+                        // for lookup on ctl.recordSchema.schema.definitions
+                        ctl.detailsPropertyKey = key;
+                        return val;
+                    }
+                });
+            if (detailsDefinitions.length !== 1) {
+                $log.error('Expected one details definition, found ' + detailsDefinitions.length);
+                return;
+            }
+
+            // Get the property names -- sorted by propertyOrder
+            ctl.headerKeys = _(detailsDefinitions[0].properties)
+                .omit('_localId')
+                .map(function(obj, propertyName) {
+                    obj.propertyName = propertyName;
+                    return obj;
+                })
+                .sortBy('propertyOrder')
+                .map('propertyName')
+                .value();
+        }
+
+        // Loads the previous page of paginated record results
+        function getPreviousRecords() {
+            loadRecords(-ctl.numRecordsPerPage);
+        }
+
+        // Loads the next page of paginated record results
+        function getNextRecords() {
+            loadRecords(ctl.numRecordsPerPage);
+        }
+
+        // Show a details modal for the given record
+        function showDetailsModal(record) {
+            $modal.open({
+                templateUrl: 'scripts/views/record/details-modal-partial.html',
+                controller: 'RecordDetailsModalController as modal',
+                size: 'lg',
+                resolve: {
+                    record: function() {
+                         return record;
+                    },
+                    recordType: function() {
+                        return ctl.recordType;
+                    },
+                    recordSchema: function() {
+                        return ctl.recordSchema;
+                    },
+                    userCanWrite: function() {
+                        return ctl.userCanWrite;
+                    }
+                }
+            });
+        }
+    }
+
+    angular.module('ase.views.record')
+    .controller('RecordListController', RecordListController);
+
+})();

--- a/app/scripts/views/record/list-directive.js
+++ b/app/scripts/views/record/list-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RecordList() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/record/list-partial.html',
+            controller: 'RecordListController',
+            controllerAs: 'ctl',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.record')
+    .directive('recordList', RecordList);
+
+})();

--- a/app/scripts/views/record/list-partial.html
+++ b/app/scripts/views/record/list-partial.html
@@ -1,0 +1,74 @@
+<div class="container">
+    <div class="row">
+        <div class="col-sm-10 col-sm-offset-1">
+            <div class="table-view">
+                <div class="table-view-container">
+                    <div class="overflow">
+                        <table class="table">
+                            <thead>
+                                <tr>
+                                    <th>Date & Time</th>
+
+                                    <th ng-repeat="headerKey in ctl.headerKeys | limitTo : ctl.maxDataColumns">
+                                        {{ ::headerKey }}
+                                    </th>
+
+                                    <!-- View/Edit links -->
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <div class="loadingrecords" ng-if="ctl.loadingRecords">
+                                    <fading-circle-spinner></fading-circle-spinner>
+                                </div>
+                                <tr ng-if="!ctl.loadingRecords" ng-repeat="record in ctl.records.results">
+                                    <td class="date">
+                                        {{ ::record.occurred_to | localizeRecordDate: 'numeric':'time' }}
+                                    </td>
+                                    <td class="detail" ng-repeat="headerKey in ctl.headerKeys | limitTo : ctl.maxDataColumns">
+                                        <ase-details-field
+                                            compact="true"
+                                            data="::record.data[ctl.detailsPropertyKey][headerKey]"
+                                            record="::record"
+                                            property="::ctl.recordSchema.schema.definitions[ctl.detailsPropertyKey].properties[headerKey]">
+                                        </ase-details-field>
+                                    </td>
+
+                                    <td class="links">
+                                        <a ng-click="ctl.showDetailsModal(record)">
+                                            <span class="glyphicon glyphicon-log-in"></span> View
+                                        </a>
+                                        <a ng-if="::ctl.userCanWrite"
+                                            ui-sref="record.edit({ rtuuid: ctl.recordType.uuid, recorduuid: record.uuid })">
+                                            <span class="glyphicon glyphicon-pencil"></span> Edit
+                                        </a>
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                        <nav>
+                            <ul class="pager" ng-if="!ctl.loadingRecords">
+                                <li class="previous" ng-if="ctl.records.previous">
+                                    <a type="button" class="btn btn-default" ng-click="ctl.getPreviousRecords()">
+                                        <span aria-hidden="true">&larr;</span> Previous</a>
+                                </li>
+                                <li ng-if="ctl.records.count" class="text-center">
+                                    <i>
+                                        Showing results
+                                        {{ ctl.currentOffset + 1}} -
+                                        {{ ctl.currentOffset + ctl.records.results.length }} of
+                                        {{ ctl.records.count }}
+                                    </i>
+                                </li>
+                                <li class="next" ng-if="ctl.records.next">
+                                    <a type="button" class="btn btn-default" ng-click="ctl.getNextRecords()">
+                                        Next <span aria-hidden="true">&rarr;</span></a>
+                                </li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/scripts/views/record/module.js
+++ b/app/scripts/views/record/module.js
@@ -1,0 +1,53 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function StateConfig($stateProvider) {
+        $stateProvider.state('record', {
+            abstract: true,
+            url: '',
+            parent: 'sidebar',
+            template: '<ui-view></ui-view>'
+        });
+        $stateProvider.state('record.add', {
+            url: '/record/add/:recordtype',
+            template: '<record-add-edit></record-add-edit>',
+            label: 'Add a Record',
+            showInNavbar: false
+        });
+        $stateProvider.state('record.edit', {
+            url: '/record/edit/:recorduuid',
+            template: '<record-add-edit></record-add-edit>',
+            label: 'Edit a Record',
+            showInNavbar: false
+        });
+        $stateProvider.state('record.list', {
+            url: '/record/list/:recordtype',
+            template: '<record-list></record-list>',
+            label: 'View all Records',
+            showInNavbar: true
+        });
+        $stateProvider.state('record.details', {
+            url: '/record/details/:recorduuid',
+            template: '<record-details></record-details>',
+            label: 'Record Details',
+            showInNavbar: false
+        });
+    }
+
+    angular.module('ase.views.record', [
+        'ngSanitize',
+        'ase.auth',
+        'ase.notifications',
+        'ase.resources',
+        'ase.schemas',
+        'ase.map-layers',
+        'datetimepicker',
+        'Leaflet',
+        'json-editor',
+        'ui.bootstrap',
+        'ui.router',
+        'angular-uuid'
+    ]).config(StateConfig);
+
+})();

--- a/app/scripts/views/recordtype/add-controller.js
+++ b/app/scripts/views/recordtype/add-controller.js
@@ -1,0 +1,67 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RTAddController($log, $scope, $state, RecordSchemas, RecordTypes, Schemas) {
+        var ctl = this;
+        initialize();
+
+        function initialize() {
+            ctl.recordType = {};
+            ctl.submitForm = submitForm;
+        }
+
+        /*
+         * Creates the record type and switches to the list view on success
+         */
+        function submitForm() {
+            RecordTypes.create(ctl.recordType, onRecordTypeCreateSuccess, function(error) {
+                $log.debug('Error while adding recordType: ', error);
+            });
+        }
+
+        /**
+         * Create blank associated record schema v1 on record type create success
+         * @return {[type]} [description]
+         */
+        function onRecordTypeCreateSuccess(recordType) {
+            $scope.$emit('ase.recordtypes.changed');
+
+            // Automatically add 'Details' related content type to all record types
+            var schema = Schemas.JsonObject();
+            schema = Schemas.addVersion4Declaration(schema); // Make root object a "real" JSON-Schema
+            var definition = Schemas.JsonObject();
+            definition.details = true; // Flag denoting that this is the 'details' definition
+            definition.description = 'Details for ' + recordType.label;
+            definition.multiple = false;
+            definition.propertyOrder = 0; // make details section first; others default to 1,000
+            /* jshint camelcase: false */
+            definition.title = definition.plural_title = recordType.label + ' Details';
+            /* jshint camelcase: true */
+            var key = Schemas.generateFieldName(definition.title);
+            schema.definitions[key] = definition;
+            schema.properties[key] = {
+                $ref: '#/definitions/' + encodeURIComponent(key),
+
+                // Set the collapsed option of the details option to true so it starts collapsed
+                options: {
+                    collapsed: true
+                }
+            };
+
+            RecordSchemas.create({
+                /* jshint camelcase: false */
+                record_type: recordType.uuid,
+                schema: schema
+                /* jshint camelcase: true */
+            }).$promise.then(function () {
+                $state.go('rt.list');
+            }, function (error) {
+                $log.debug('Error while creating recordschema:', error);
+            });
+        }
+    }
+
+    angular.module('ase.views.recordtype')
+    .controller('RTAddController', RTAddController);
+})();

--- a/app/scripts/views/recordtype/add-directive.js
+++ b/app/scripts/views/recordtype/add-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RTAdd() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/recordtype/add-edit-partial.html',
+            controller: 'RTAddController',
+            controllerAs: 'rt',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.recordtype')
+    .directive('aseRtAdd', RTAdd);
+
+})();

--- a/app/scripts/views/recordtype/add-edit-partial.html
+++ b/app/scripts/views/recordtype/add-edit-partial.html
@@ -1,0 +1,53 @@
+<div class="form-area">
+    <div class="col-sm-8 col-sm-offset-3">
+        <div class="form-area-heading">
+            <h2 ng-show="!rt.recordType.uuid">Add New Record Type</h2>
+            <h2 ng-show="rt.recordType.uuid">Edit Record Type</h2>
+            <div class="content-border"></div>
+        </div>
+
+        <form name="rtForm" novalidate ng-submit="rt.submitForm()">
+            <div class="form-group col-sm-6">
+                <label for="single-title">Single Title</label>
+                <input required type="text" name="label" ng-model="rt.recordType.label"
+                       class="form-control" id="single-title" placeholder="Incident"
+                       ng-minlength="3" ng-maxlength="64" />
+                <p ng-show="rtForm.label.$invalid && !rtForm.label.$pristine" class="help-block">
+                    Single Title is required
+                </p>
+                <p ng-show="rtForm.label.$error.minlength" class="help-block">Single Title too short</p>
+                <p ng-show="rtForm.label.$error.maxlength" class="help-block">Single Title too long</p>
+            </div>
+            <div class="form-group col-sm-6">
+                <label for="plural-title">Plural Title</label>
+                <input required type="text" name="plural_label" ng-model="rt.recordType.plural_label"
+                       class="form-control" id="plural-title" placeholder="Incidents"
+                       ng-minlength="3" ng-maxlength="64" />
+                <p ng-show="rtForm.plural_label.$invalid && !rtForm.plural_label.$pristine" class="help-block">
+                    Plural Title is required
+                </p>
+                <p ng-show="rtForm.plural_label.$error.minlength" class="help-block">Plural Title too short</p>
+                <p ng-show="rtForm.plural_label.$error.maxlength" class="help-block">Plural Title too long</p>
+            </div>
+            <div class="form-group col-sm-12">
+                <label for="description">Description</label>
+                <textarea required name="description" class="form-control" ng-model="rt.recordType.description"
+                          id="description" rows="5" placeholder="Lorem ipsum"
+                          ng-minlength="3" ng-maxlength="255">
+                </textarea>
+                <p ng-show="rtForm.label.$invalid && !rtForm.label.$pristine" class="help-block">
+                    Description is required
+                </p>
+                <p ng-show="rtForm.description.$error.minlength" class="help-block">Description too short</p>
+                <p ng-show="rtForm.description.$error.maxlength" class="help-block">Description too long</p>
+            </div>
+
+            <div class="save-area">
+                <button type="submit" class="btn btn-default" ng-disabled="rtForm.$invalid">
+                    Save
+                </button>
+                <button type="button" ui-sref="rt.list" class="btn btn-default">Cancel</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/app/scripts/views/recordtype/edit-controller.js
+++ b/app/scripts/views/recordtype/edit-controller.js
@@ -1,0 +1,29 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RTEditController($log, $scope, $state, $stateParams, RecordTypes) {
+        var ctl = this;
+        initialize();
+
+        function initialize() {
+            ctl.recordType = RecordTypes.get({ id: $stateParams.uuid });
+            ctl.submitForm = submitForm;
+        }
+
+        /*
+         * Updates the record type and switches to the list view on success
+         */
+        function submitForm() {
+            RecordTypes.update(ctl.recordType, function() {
+                $scope.$emit('ase.recordtypes.changed');
+                $state.go('rt.list');
+            }, function(error) {
+                $log.debug('Error while editing recordType: ', error);
+            });
+        }
+    }
+
+    angular.module('ase.views.recordtype')
+    .controller('RTEditController', RTEditController);
+})();

--- a/app/scripts/views/recordtype/edit-directive.js
+++ b/app/scripts/views/recordtype/edit-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RTEdit() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/recordtype/add-edit-partial.html',
+            controller: 'RTEditController',
+            controllerAs: 'rt',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.recordtype')
+    .directive('aseRtEdit', RTEdit);
+
+})();

--- a/app/scripts/views/recordtype/list-controller.js
+++ b/app/scripts/views/recordtype/list-controller.js
@@ -1,0 +1,43 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RTListController($log, $scope, RecordTypes) {
+        var ctl = this;
+        initialize();
+
+        function initialize() {
+            ctl.deactivateRecordType = deactivateRecordType;
+            refreshRecordTypes();
+            $scope.$on('ase.recordtypes.changed', refreshRecordTypes);
+        }
+
+        /*
+         * Queries for an updated set of active record types
+         */
+        function refreshRecordTypes() {
+            ctl.recordTypes = RecordTypes.query({ active: 'True' });
+        }
+
+        /*
+         * Updates a record type with a deactivated state
+         * @param {object} recordType Record type to deactivate
+         */
+        function deactivateRecordType(recordType) {
+            // TODO: need confirmation dialog/spinner/error handling/etc.
+            //   This applies to all queries and should be dealt with in a new task.
+            RecordTypes.update({
+                uuid: recordType.uuid,
+                active: false
+            }, function() {
+                $scope.$emit('ase.recordtypes.changed');
+            }, function(error) {
+                $log.debug('Error while deleting recordType: ', error);
+            });
+        }
+    }
+
+    angular.module('ase.views.recordtype')
+    .controller('RTListController', RTListController);
+
+})();

--- a/app/scripts/views/recordtype/list-directive.js
+++ b/app/scripts/views/recordtype/list-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RTList() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/recordtype/list-partial.html',
+            controller: 'RTListController',
+            controllerAs: 'rtList',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.recordtype')
+    .directive('aseRtList', RTList);
+
+})();

--- a/app/scripts/views/recordtype/list-partial.html
+++ b/app/scripts/views/recordtype/list-partial.html
@@ -1,0 +1,44 @@
+<div class="form-area">
+    <div class="col-sm-8 col-sm-offset-3">
+        <div class="form-area-heading">
+            <h2>All Record Types</h2>
+            <div class="button-container">
+                <button type="button" ui-sref="rt.add" class="btn btn-default">Add new type</button>
+            </div>
+            <div class="content-border"></div>
+        </div>
+        <div class="form-area-body">
+            <div ng-repeat="recordType in rtList.recordTypes | orderBy:'label'" class="row">
+                <div class="type">
+                    <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 10 22" enable-background="new 0 0 10 22" xml:space="preserve">
+                        <path opacity="0.5" fill-rule="evenodd" clip-rule="evenodd" fill="#4A4A4A" d="M4.6,20.6L8,17.3H1.3L4.6,20.6z M1.3,4H8L4.6,0.7 L1.3,4z M8,10.7c0-1.8-1.5-3.3-3.3-3.3c-1.8,0-3.3,1.5-3.3,3.3c0,1.8,1.5,3.3,3.3,3.3C6.5,14,8,12.5,8,10.7z"/>
+                    </svg>
+                    <h4>
+                      <a ui-sref="rt.edit({ uuid: recordType.uuid })">{{ recordType.label }}</a>
+                    </h4>
+                    <a ui-sref="rt.preview({ uuid: recordType.uuid })" role="button" class="edit">
+                        <p>Preview</p>
+                        <svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 95 100" enable-background="new 0 0 80 100" xml:space="preserve">
+                            <polygon points="92.901,35.938 90.089,12.031 67.427,21.513 76.354,26.566 56.799,61.33 43.643,46.857 7.099,87.969 20.268,87.969 43.724,61.58 58.693,78.045 84.92,31.418"/>
+                        </svg>
+                    </a>
+                    <a ase-confirm-click="rtList.deactivateRecordType(recordType)"
+                       role="button" class="delete">
+                        <p>Trash</p>
+                        <svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 80 100" enable-background="new 0 0 80 100" xml:space="preserve">
+                            <path d="M6.1,39l5.5,48.5c0.3,2.3,11.4,9.9,27.5,9.9c16.1,0,27.3-7.6,27.6-9.9L72.2,39c-8.4,4.7-21,6.9-33.1,6.9 C27.1,46,14.5,43.7,6.1,39z M55,9l-4.3-4.8c-1.7-2.4-3.5-2.8-7-2.8h-9.2c-3.5,0-5.3,0.4-7,2.8L23.4,9C10.5,11.3,1.2,17.2,1.2,21.6 v0.9c0,7.7,17,14,38,14c21,0,38-6.3,38-14v-0.9C77.2,17.2,67.9,11.3,55,9z M49.5,20.2l-6.3-6.7h-8.2l-6.3,6.7h-8.5 c0,0,9.3-11.1,10.6-12.6c1-1.2,1.9-1.6,3.2-1.6h10.2c1.3,0,2.2,0.4,3.2,1.6C48.7,9.1,58,20.2,58,20.2H49.5z"/>
+                        </svg>
+                    </a>
+                    <a ui-sref="rt.edit({ uuid: recordType.uuid })" role="button" class="edit">
+                        <p>Edit</p>
+                        <svg version="1.1" id="Layer_3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+                        viewBox="0 0 80 80" enable-background="new 0 0 80 80" xml:space="preserve">
+                            <g><path d="M71.8,8.2C64.6,1,59.2,2.1,59.2,2.1L33.9,27.3L5,56.2L0,80l23.8-5.1l28.9-28.9l25.3-25.3C77.9,20.8,79,15.4,71.8,8.2z M22.4,72.1l-8.1,1.7c-0.8-1.5-1.7-2.9-3.5-4.7c-1.7-1.7-3.2-2.7-4.7-3.5l1.8-8.1l2.3-2.3c0,0,4.4,0.1,9.4,5.1c5,5,5.1,9.4,5.1,9.4 L22.4,72.1z"/></g>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+            <div class="dark-border"></div>
+        </div>
+    </div>
+</div>

--- a/app/scripts/views/recordtype/module.js
+++ b/app/scripts/views/recordtype/module.js
@@ -1,0 +1,57 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function StateConfig($stateProvider) {
+        $stateProvider.state('rt', {
+            abstract: true,
+            parent: 'sidebar',
+            url: '/recordtype',
+            template: '<ui-view></ui-view>'
+        });
+        $stateProvider.state('rt.list', {
+            url: '',
+            template: '<ase-rt-list></ase-rt-list>'
+        });
+        $stateProvider.state('rt.add', {
+            url: '/add',
+            template: '<ase-rt-add></ase-rt-add>'
+        });
+        $stateProvider.state('rt.edit', {
+            url: '/edit/:uuid',
+            template: '<ase-rt-edit></ase-rt-edit>'
+        });
+        $stateProvider.state('rt.preview', {
+            url: '/preview/:uuid',
+            template: '<ase-rt-preview></ase-rt-preview>'
+        });
+        $stateProvider.state('rt.related', {
+            url: '/related/:uuid',
+            template: '<ase-rt-related></ase-rt-related>'
+        });
+        $stateProvider.state('rt.related-edit', {
+            url: '/related/:uuid/edit/:schema',
+            template: '<ase-rt-related-edit></ase-rt-related-edit>'
+        });
+        $stateProvider.state('rt.related-add', {
+            url: '/related/:uuid/add',
+            template: '<ase-rt-related-add></ase-rt-related-add>'
+        });
+        $stateProvider.state('rt.schema-edit', {
+            url: '/related/:uuid/schema/:schema',
+            template: '<ase-rt-schema-edit></ase-rt-schema-edit>'
+        });
+    }
+
+    angular.module('ase.views.recordtype', [
+        'ui.router',
+        'ui.bootstrap',
+        'json-editor',
+        'ase.config',
+        'ase.directives',
+        'ase.notifications',
+        'ase.schemas',
+        'ase.resources'
+    ]).config(StateConfig);
+
+})();

--- a/app/scripts/views/recordtype/preview-controller.js
+++ b/app/scripts/views/recordtype/preview-controller.js
@@ -1,0 +1,58 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RTPreviewController($stateParams, RecordTypes, RecordSchemas) {
+        var ctl = this;
+        ctl.onDataChange = angular.noop;
+        initialize();
+
+        function initialize() {
+            loadRecordType()
+                .then(loadRecordSchema)
+                .then(onSchemaReady);
+        }
+
+        // Helper for loading the record type
+        function loadRecordType () {
+            return RecordTypes.get({ id: $stateParams.uuid })
+                .$promise.then(function(recordType) {
+                    ctl.recordType = recordType;
+                });
+        }
+
+        // Helper for loading the record schema
+        function loadRecordSchema() {
+            /* jshint camelcase: false */
+            var currentSchemaId = ctl.recordType.current_schema;
+            /* jshint camelcase: true */
+
+            return RecordSchemas.get({ id: currentSchemaId })
+                .$promise.then(function(recordSchema) {
+                    ctl.recordSchema = recordSchema;
+                });
+        }
+
+        // Called after all prerequesite data has been loaded
+        function onSchemaReady() {
+            /* jshint camelcase: false */
+            ctl.editor = {
+                id: 'preview-editor',
+                options: {
+                    schema: ctl.recordSchema.schema,
+                    disable_edit_json: true,
+                    disable_properties: true,
+                    disable_array_add: false,
+                    theme: 'bootstrap3',
+                    show_errors: 'change',
+                    no_additional_properties: true
+                },
+                errors: []
+            };
+            /* jshint camelcase: true */
+        }
+    }
+
+    angular.module('ase.views.recordtype')
+    .controller('RTPreviewController', RTPreviewController);
+})();

--- a/app/scripts/views/recordtype/preview-directive.js
+++ b/app/scripts/views/recordtype/preview-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RTPreview() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/recordtype/preview-partial.html',
+            controller: 'RTPreviewController',
+            controllerAs: 'rtPreview',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.recordtype')
+    .directive('aseRtPreview', RTPreview);
+
+})();

--- a/app/scripts/views/recordtype/preview-partial.html
+++ b/app/scripts/views/recordtype/preview-partial.html
@@ -1,0 +1,13 @@
+<div class="form-area">
+    <div class="col-sm-8 col-sm-offset-3">
+        <div class="form-area-heading">
+            <h2>{{ rtPreview.recordType.label }} input form preview </h2>
+            <div class="content-border"></div>
+        </div>
+        <json-editor editor-id="{{ rtPreview.editor.id }}"
+                     options="rtPreview.editor.options"
+                     on-data-change="rtPreview.onDataChange"
+                     class="form-area-body">
+        </json-editor>
+    </div>
+</div>

--- a/app/scripts/views/recordtype/related-add-directive.js
+++ b/app/scripts/views/recordtype/related-add-directive.js
@@ -1,0 +1,107 @@
+
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RTRelatedAddController($log, $state, $stateParams, RecordSchemas, RecordTypes, Schemas) {
+        var ctl = this;
+        ctl.submitForm = submitForm;
+        initialize();
+
+        function initialize() {
+            ctl.definition = Schemas.JsonObject();
+            ctl.definition = Schemas.addRelatedContentFields(ctl.definition);
+            RecordTypes.get({ id: $stateParams.uuid }).$promise.then(function (data) {
+                ctl.recordType = data;
+                /* jshint camelcase:false */
+                ctl.currentSchema = RecordSchemas.get({ id: ctl.recordType.current_schema });
+                /* jshint camelcase:true */
+            });
+        }
+
+        /**
+         * Updates related definitions to include a property order attribute
+         * @param {object} properties to update propertyOrder attribute
+         */
+        function addPropertyOrder(properties) {
+            var currentPropertyOrder = 0;
+            _.mapValues(properties, function(property) {
+                var propertyOrder = property.propertyOrder;
+                if (propertyOrder && propertyOrder > currentPropertyOrder) {
+                    currentPropertyOrder = propertyOrder;
+                }
+            });
+
+            _.forEach(properties, function(property) {
+                if (!property.propertyOrder && property.propertyOrder !== 0) {
+                    currentPropertyOrder = currentPropertyOrder + 1;
+                    property.propertyOrder = currentPropertyOrder;
+                }
+            });
+        }
+
+        function submitForm() {
+            var key = Schemas.generateFieldName(ctl.definition.title);
+            if (ctl.currentSchema.schema.definitions[key]) {
+                $log.debug('Title', key, 'exists for current schema');
+                return;
+            }
+
+            ctl.currentSchema.schema.definitions[key] = ctl.definition;
+
+            // Use an array or object depending on the 'multiple' setting
+            var ref = '#/definitions/' + encodeURIComponent(key);
+            if (ctl.definition.multiple) {
+                ctl.currentSchema.schema.properties[key] = {
+                    type: 'array',
+                    items: {
+                        $ref: ref
+                    },
+                    title: ctl.definition.title,
+                    /* jshint camelcase:false */
+                    plural_title: ctl.definition.plural_title
+                    /* jshint camelcase:true */
+                };
+            } else {
+                ctl.currentSchema.schema.properties[key] = {
+                    $ref: ref
+                };
+            }
+
+            // Set the collapsed option to true so all objects start collapsed when viewing
+            ctl.currentSchema.schema.properties[key].options = {
+                collapsed: true
+            };
+
+            addPropertyOrder(ctl.currentSchema.schema.properties);
+
+            RecordSchemas.create({
+                /* jshint camelcase:false */
+                schema: ctl.currentSchema.schema,
+                record_type: ctl.recordType.uuid
+                /* jshint camelcase:true */
+            }, function () {
+                $state.go('rt.related', {uuid: ctl.recordType.uuid});
+            }, function (error) {
+                $log.debug('Error saving new schema: ', error);
+            });
+        }
+    }
+
+    /* ngInject */
+    function RTRelatedAdd() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/recordtype/related-add-edit-partial.html',
+            controller: 'RTRelatedAddController',
+            controllerAs: 'rtRelated',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.recordtype')
+    .controller('RTRelatedAddController', RTRelatedAddController)
+    .directive('aseRtRelatedAdd', RTRelatedAdd);
+
+})();

--- a/app/scripts/views/recordtype/related-add-edit-partial.html
+++ b/app/scripts/views/recordtype/related-add-edit-partial.html
@@ -1,0 +1,64 @@
+
+<div class="form-area">
+    <div class="col-sm-8 col-sm-offset-3">
+        <div class="form-area-heading">
+            <h2 ng-show="!rtRelated.schemaKey">Add New Related Content</h2>
+            <h2 ng-show="rtRelated.schemaKey">Edit Related Content</h2>
+            <div class="content-border"></div>
+        </div>
+
+        <form name="rtForm" novalidate ng-submit="rtRelated.submitForm()">
+            <div class="form-group col-sm-6">
+                <label for="single-title">Single Title</label>
+                <input required type="text" name="label" ng-model="rtRelated.definition.title"
+                       ng-readonly="!!rtRelated.schemaKey"
+                       class="form-control" id="single-title" placeholder="Incident"
+                       ng-minlength="3" ng-maxlength="64" />
+                <p ng-show="rtForm.title.$invalid && !rtForm.title.$pristine" class="help-block">
+                    Single Title is required
+                </p>
+                <p ng-show="rtForm.title.$error.minlength" class="help-block">Single Title too short</p>
+                <p ng-show="rtForm.title.$error.maxlength" class="help-block">Single Title too long</p>
+            </div>
+            <div class="form-group col-sm-6">
+                <label for="plural-title">Plural Title</label>
+                <input required type="text" name="plural_label" ng-model="rtRelated.definition.plural_title"
+                       class="form-control" id="plural-title" placeholder="Incidents"
+                       ng-minlength="3" ng-maxlength="64" />
+                <p ng-show="rtForm.plural_title.$invalid && !rtForm.plural_title.$pristine" class="help-block">
+                    Plural Title is required
+                </p>
+                <p ng-show="rtForm.plural_title.$error.minlength" class="help-block">Plural Title too short</p>
+                <p ng-show="rtForm.plural_title.$error.maxlength" class="help-block">Plural Title too long</p>
+            </div>
+            <div class="form-group col-sm-12">
+                <label for="description">Description</label>
+                <textarea required name="description" class="form-control" ng-model="rtRelated.definition.description"
+                          id="description" rows="5" placeholder="Lorem ipsum"
+                          ng-minlength="3" ng-maxlength="255">
+                </textarea>
+                <p ng-show="rtForm.description.$invalid && !rtForm.description.$pristine" class="help-block">
+                    Description is required
+                </p>
+                <p ng-show="rtForm.description.$error.minlength" class="help-block">Description too short</p>
+                <p ng-show="rtForm.description.$error.maxlength" class="help-block">Description too long</p>
+            </div>
+
+            <div class="form-group col-sm-12">
+                <label for="multiple">Allow multiple?</label>
+                <input type="checkbox" name="multiple"
+                       ng-disabled="!!rtRelated.schemaKey"
+                       ng-model="rtRelated.definition.multiple" id="multiple">
+                </input>
+            </div>
+
+            <div class="save-area">
+                <button type="submit" class="btn btn-default" ng-disabled="rtForm.$invalid">
+                    Save
+                </button>
+                <button type="button" ui-sref="rt.related({uuid: rtRelated.recordType.uuid})"
+                        class="btn btn-default">Cancel</button>
+            </div>
+        </form>
+    </div>
+</div>

--- a/app/scripts/views/recordtype/related-controller.js
+++ b/app/scripts/views/recordtype/related-controller.js
@@ -1,0 +1,36 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RTRelatedController($stateParams, RecordSchemas, RecordTypes) {
+        var ctl = this;
+        ctl.deleteSchema = deleteSchema;
+        initialize();
+
+        function initialize() {
+            RecordTypes.get({ id: $stateParams.uuid }).$promise.then(function (data) {
+                ctl.recordType = data;
+                /* jshint camelcase:false */
+                ctl.currentSchema = RecordSchemas.get({ id: ctl.recordType.current_schema });
+                /* jshint camelcase:true */
+            });
+        }
+
+        function deleteSchema(key) {
+            if (ctl.currentSchema.schema.definitions[key]) {
+                delete ctl.currentSchema.schema.definitions[key];
+                delete ctl.currentSchema.schema.properties[key];
+                // TODO: Error handle and revert delete if failure
+                RecordSchemas.create({
+                    /* jshint camelcase:false */
+                    record_type: ctl.recordType.uuid,
+                    schema: ctl.currentSchema.schema
+                    /* jshint camelcase:true */
+                });
+            }
+        }
+    }
+
+    angular.module('ase.views.recordtype')
+    .controller('RTRelatedController', RTRelatedController);
+})();

--- a/app/scripts/views/recordtype/related-directive.js
+++ b/app/scripts/views/recordtype/related-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RTRelated() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/recordtype/related-partial.html',
+            controller: 'RTRelatedController',
+            controllerAs: 'rt',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.recordtype')
+    .directive('aseRtRelated', RTRelated);
+
+})();

--- a/app/scripts/views/recordtype/related-edit-directive.js
+++ b/app/scripts/views/recordtype/related-edit-directive.js
@@ -1,0 +1,58 @@
+
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RTRelatedEditController($log, $state, $stateParams, RecordSchemas, RecordTypes, Schemas) {
+        var ctl = this;
+        var currentSchema = null;
+        ctl.submitForm = submitForm;
+        initialize();
+
+        function initialize() {
+            ctl.schemaKey = $stateParams.schema;
+            ctl.definition = {};
+            RecordTypes.get({ id: $stateParams.uuid }).$promise.then(function (data) {
+                ctl.recordType = data;
+                /* jshint camelcase: false */
+                RecordSchemas.get({ id: ctl.recordType.current_schema }).$promise.then(function (recordSchema) {
+                /* jshint camelcase: true */
+                    currentSchema = recordSchema;
+                    ctl.definition = currentSchema.schema.definitions[ctl.schemaKey];
+                });
+            });
+        }
+
+        function submitForm() {
+            var key = Schemas.generateFieldName(ctl.definition.title);
+            currentSchema.schema.definitions[key] = ctl.definition;
+            RecordSchemas.create({
+                /* jshint camelcase: false */
+                schema: currentSchema.schema,
+                record_type: ctl.recordType.uuid
+                /* jshint camelcase: true */
+            }, function () {
+                $state.go('^.related', {uuid: ctl.recordType.uuid});
+            }, function (error) {
+                $log.debug('Error saving new schema: ', error);
+            });
+        }
+    }
+
+    /* ngInject */
+    function RTRelatedEdit() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/recordtype/related-add-edit-partial.html',
+            controller: 'RTRelatedEditController',
+            controllerAs: 'rtRelated',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.recordtype')
+    .controller('RTRelatedEditController', RTRelatedEditController)
+    .directive('aseRtRelatedEdit', RTRelatedEdit);
+
+})();

--- a/app/scripts/views/recordtype/related-partial.html
+++ b/app/scripts/views/recordtype/related-partial.html
@@ -1,0 +1,44 @@
+<div class="form-area">
+    <div class="col-sm-8 col-sm-offset-3">
+        <div class="form-area-heading">
+            <h2>Related Content for {{ rt.recordType.plural_label }}</h2>
+            <div class="button-container">
+                <button type="button" class="btn btn-default" ui-sref="rt.related-add({uuid: rt.recordType.uuid })">Add new content</button>
+            </div>
+            <div class="content-border"></div>
+        </div>
+        <div class="form-area-body">
+            <div ng-repeat="(key, definition) in rt.currentSchema.schema.definitions">
+                <div class="row" ng-class="{ 'multiple': definition.multiple }">
+                    <div class="type">
+                        <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 10 22" enable-background="new 0 0 10 22" xml:space="preserve">
+                            <path opacity="0.5" fill-rule="evenodd" clip-rule="evenodd" fill="#4A4A4A" d="M4.6,20.6L8,17.3H1.3L4.6,20.6z M1.3,4H8L4.6,0.7 L1.3,4z M8,10.7c0-1.8-1.5-3.3-3.3-3.3c-1.8,0-3.3,1.5-3.3,3.3c0,1.8,1.5,3.3,3.3,3.3C6.5,14,8,12.5,8,10.7z"/>
+                        </svg>
+                        <a ui-sref="rt.related-edit({uuid: rt.recordType.uuid, schema: key})"><h4>{{ definition.plural_title }}</h4></a>
+
+                        <!--Placeholder styling for denoting 'multiple'. A 'multiple' class has been added
+                            to the row for future styling work.
+                          -->
+                        <h5 ng-if="definition.multiple">[MULTIPLE]</h5>
+
+                        <a ase-confirm-click="rt.deleteSchema(key)" role="button" class="delete"
+                           ng-if="!definition.details">
+                            <p>Trash</p>
+                            <svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 80 100" enable-background="new 0 0 80 100" xml:space="preserve">
+                                <path d="M6.1,39l5.5,48.5c0.3,2.3,11.4,9.9,27.5,9.9c16.1,0,27.3-7.6,27.6-9.9L72.2,39c-8.4,4.7-21,6.9-33.1,6.9 C27.1,46,14.5,43.7,6.1,39z M55,9l-4.3-4.8c-1.7-2.4-3.5-2.8-7-2.8h-9.2c-3.5,0-5.3,0.4-7,2.8L23.4,9C10.5,11.3,1.2,17.2,1.2,21.6 v0.9c0,7.7,17,14,38,14c21,0,38-6.3,38-14v-0.9C77.2,17.2,67.9,11.3,55,9z M49.5,20.2l-6.3-6.7h-8.2l-6.3,6.7h-8.5 c0,0,9.3-11.1,10.6-12.6c1-1.2,1.9-1.6,3.2-1.6h10.2c1.3,0,2.2,0.4,3.2,1.6C48.7,9.1,58,20.2,58,20.2H49.5z"/>
+                            </svg>
+                        </a>
+                        <a ui-sref="rt.schema-edit({uuid: rt.recordType.uuid, schema: key})" role="button" class="edit">
+                            <p>Edit</p>
+                            <svg version="1.1" id="Layer_3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+                            viewBox="0 0 80 80" enable-background="new 0 0 80 80" xml:space="preserve">
+                                <g><path d="M71.8,8.2C64.6,1,59.2,2.1,59.2,2.1L33.9,27.3L5,56.2L0,80l23.8-5.1l28.9-28.9l25.3-25.3C77.9,20.8,79,15.4,71.8,8.2z M22.4,72.1l-8.1,1.7c-0.8-1.5-1.7-2.9-3.5-4.7c-1.7-1.7-3.2-2.7-4.7-3.5l1.8-8.1l2.3-2.3c0,0,4.4,0.1,9.4,5.1c5,5,5.1,9.4,5.1,9.4 L22.4,72.1z"/></g>
+                            </svg>
+                        </a>
+                    </div>
+                </div>
+                <div class="dark-border"></div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/scripts/views/recordtype/schema/edit-controller.js
+++ b/app/scripts/views/recordtype/schema/edit-controller.js
@@ -1,0 +1,199 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RTSchemaEditController($log, $stateParams, BuilderSchemas, RecordTypes,
+                                    RecordSchemas, Schemas, Notifications, JsonEditorDefaults) {
+        var ctl = this;
+        var editorData = null;
+
+        initialize();
+
+        function initialize() {
+            ctl.schemaKey = $stateParams.schema;
+            ctl.onDataChange = onDataChange;
+            ctl.onSaveClicked = onSaveClicked;
+            loadRecordType()
+                .then(loadRecordSchema)
+                .then(loadRelatedBuilderSchema)
+                .then(onSchemaReady);
+        }
+
+        // Helper for loading the record type
+        function loadRecordType () {
+            return RecordTypes.get({ id: $stateParams.uuid })
+                .$promise.then(function(recordType) {
+                    ctl.recordType = recordType;
+                });
+        }
+
+        // Helper for loading the record schema
+        function loadRecordSchema() {
+            /* jshint camelcase: false */
+            var currentSchemaId = ctl.recordType.current_schema;
+            /* jshint camelcase: true */
+
+            return RecordSchemas.get({ id: currentSchemaId })
+                .$promise.then(function(recordSchema) {
+                    ctl.recordSchema = recordSchema;
+                    ctl.schemaTitle = recordSchema.schema.definitions[ctl.schemaKey].title;
+                });
+        }
+
+        // Helper for loading the related builder schema
+        function loadRelatedBuilderSchema () {
+            return BuilderSchemas.get({ name: 'related' })
+                .$promise.then(function(relatedBuilderSchema) {
+                    ctl.relatedBuilderSchema = relatedBuilderSchema;
+                });
+        }
+
+        // Called after all prerequisite data has been loaded
+        function onSchemaReady() {
+            // Get a list of the titles of all relatedContentTypes which have '_localId' as
+            // a property.
+            var referable = _.pick(ctl.recordSchema.schema.definitions, function(definition) {
+                return !!definition.properties._localId;
+            });
+            // Don't allow referring to the type currently being edited
+            referable = _.pick(referable, function(definition, key) {
+                return key !== ctl.schemaKey;
+            });
+            // Map referable to objects -- needed in newer versions of json-editor
+            referable = _.map(referable, function(definition, key) {
+                return {
+                    value: key,
+                    title: definition.title
+                };
+            });
+
+            // Modify the relatedBuilderSchema in-place in order to allow selecting a related
+            // content type as the target of an internal reference.
+            ctl.relatedBuilderSchema
+                .definitions
+                .localReference
+                .properties
+                .referenceTarget
+                .enumSource = [{
+                    source: referable,
+                    title: '{{item.title}}',
+                    value: '{{item.value}}'
+                }];
+
+            // Need to call toJSON here in order to strip the additional angular
+            // resource properties, as they don't play well with json-editor.
+            var schema = ctl.relatedBuilderSchema.toJSON();
+
+            // Populate saved properties
+            /* jshint camelcase: false */
+            var definition = ctl.recordSchema.schema.definitions[ctl.schemaKey];
+            schema.description = definition.description;
+            schema.title = definition.title;
+            schema.plural_title = definition.plural_title;
+            /* jshint camelcase: true */
+            var initialData = Schemas.schemaFormDataFromDefinition(definition);
+            $log.debug('Initializing form with startval', initialData);
+
+            // Configure the json-editor
+            /* jshint camelcase: false */
+            ctl.editor = {
+                id: 'schema-editor',
+                options: {
+                    schema: schema,
+                    disable_edit_json: true,
+                    disable_properties: true,
+                    disable_array_add: false,
+                    theme: 'bootstrap3',
+                    show_errors: 'change',
+                    no_additional_properties: true,
+                    startval: initialData
+                },
+                errors: []
+            };
+            /* jshint camelcase: true */
+
+            JsonEditorDefaults.customValidators.push(validateNoSelfReference);
+        }
+
+        function onDataChange(newData, validationErrors) {
+            // Update editorData reference: used later during save
+            editorData = newData;
+
+            // Perform custom validation
+            var customErrors = Schemas.validateSchemaFormData(newData);
+            ctl.editor.errors = validationErrors.concat(customErrors);
+
+            $log.debug('Schema Entry Form data:', newData,
+                       'Errors:', validationErrors,
+                       'CustomErrors:', customErrors);
+        }
+
+        // Make sure that reference fields aren't referring to this type; this causes
+        // an infinite recursion when displaying the edit form.
+        function validateNoSelfReference(schema, value, path) {
+            var errors = [];
+            var pathKey = 'referenceTarget';
+            if (!value || typeof value !== 'object' || !value.referenceTarget) {
+                return errors;
+            }
+
+            if (value.referenceTarget === ctl.schemaKey) {
+                errors.push({
+                    path: path,
+                    property: pathKey,
+                    message: 'Relationship must be to a different related content type'
+                });
+            }
+            return errors;
+        }
+
+        function onSaveClicked() {
+            // First we confirm that the form data is valid; then we know we have something which
+            // we can transform into a Data Form Schema.
+            if (ctl.editor.errors.length > 0) {
+                Notifications.show({
+                    displayClass: 'alert-danger',
+                    text: 'Saving failed: invalid data schema definition'
+                });
+                $log.debug('Validation errors on save:', ctl.editor.errors);
+                return;
+            }
+            // All is well; serialize the form data into a JSON-Schema snippet.
+            var dataToSave = Schemas.definitionFromSchemaFormData(editorData,
+                    ctl.recordSchema.schema,
+                    ctl.schemaKey);
+            $log.debug('Serialized schema to save:', dataToSave);
+
+            // Extend the definitions with the new data. Need to extend rather than
+            // update in order to preserve the other attributes (title/etc.)
+            var definitions = ctl.recordSchema.schema.definitions;
+            definitions[ctl.schemaKey] = angular.extend(definitions[ctl.schemaKey], dataToSave);
+
+            // Save the updated schema
+            RecordSchemas.create({
+                /* jshint camelcase:false */
+                record_type: ctl.recordType.uuid,
+                schema: ctl.recordSchema.schema
+                /* jshint camelcase:true */
+            }).$promise
+                .then(function() {
+                    Notifications.show({
+                        text: 'Schema saved successfully',
+                        displayClass: 'alert-success',
+                        timeout: 3000
+                    });
+                })
+                .catch(function(error) {
+                    $log.debug('Error saving schema:', error);
+                    Notifications.show({
+                        text: 'Error saving schema: ' + error.statusText,
+                        displayClass: 'alert-danger',
+                        timeout: 3000
+                    });
+                });
+        }
+    }
+
+    angular.module('ase.views.recordtype')
+    .controller('RTSchemaEditController', RTSchemaEditController);
+})();

--- a/app/scripts/views/recordtype/schema/edit-directive.js
+++ b/app/scripts/views/recordtype/schema/edit-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function RTSchemaEdit() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/recordtype/schema/edit-partial.html',
+            controller: 'RTSchemaEditController',
+            controllerAs: 'rtSchemaEdit',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.recordtype')
+    .directive('aseRtSchemaEdit', RTSchemaEdit);
+
+})();

--- a/app/scripts/views/recordtype/schema/edit-partial.html
+++ b/app/scripts/views/recordtype/schema/edit-partial.html
@@ -1,0 +1,21 @@
+<div class="form-area">
+    <div class="col-sm-8 col-sm-offset-3">
+        <ase-notifications></ase-notifications>
+        <div class="form-area-heading">
+            <h2>{{ ::rtSchemaEdit.schemaTitle }}</h2>
+            <div class="content-border"></div>
+        </div>
+        <json-editor editor-id="{{ rtSchemaEdit.editor.id }}"
+                     options="rtSchemaEdit.editor.options"
+                     on-data-change="rtSchemaEdit.onDataChange"
+                     class="form-area-body">
+        </json-editor>
+        <div class="save-area">
+            <button type="button" class="btn btn-default" ng-disabled="rtSchemaEdit.editor.errors.length > 0"
+                    ng-click="rtSchemaEdit.onSaveClicked()">Save</button>
+            <button type="button" class="btn btn-default"
+                    ui-sref="rt.related({uuid: rtSchemaEdit.recordType.uuid })">Cancel</button>
+            </div>
+        </div>
+    </div>
+</div>

--- a/app/scripts/views/settings/list-controller.js
+++ b/app/scripts/views/settings/list-controller.js
@@ -1,0 +1,21 @@
+(function() {
+    'use strict';
+
+    /**
+     * @ngInject
+     */
+    function SettingsListController () {
+        /* Currently empty; in the future, can be used to control
+         * a  settings page.
+         */
+        initialize();
+
+        function initialize() {
+            return;
+        }
+    }
+
+    angular.module('ase.views.settings')
+        .controller('SettingsListController', SettingsListController);
+
+})();

--- a/app/scripts/views/settings/list-directive.js
+++ b/app/scripts/views/settings/list-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function SettingsList() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/settings/list-partial.html',
+            controller: 'SettingsListController',
+            controllerAs: 'SettingsList',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.settings')
+    .directive('aseSettingsList', SettingsList);
+
+})();

--- a/app/scripts/views/settings/list-partial.html
+++ b/app/scripts/views/settings/list-partial.html
@@ -1,0 +1,13 @@
+<div class="form-area">
+    <div class="col-sm-12 col-sm-offset-3">
+        <ase-notifications></ase-notifications>
+        <div class="form-area-heading">
+            <h2>System Settings</h2>
+            <div class="content-border"></div>
+        </div>
+
+        <div class="form-area-body">
+            <div class="col-sm-12"></div>
+        </div>
+    </div>
+</div>

--- a/app/scripts/views/settings/module.js
+++ b/app/scripts/views/settings/module.js
@@ -1,0 +1,33 @@
+(function () {
+'use strict';
+
+    /**
+     * @ngInject
+     */
+    function StateConfig($stateProvider) {
+
+        $stateProvider.state('settings', {
+            abstract: true,
+            parent: 'sidebar',
+            url: '/settings',
+            template: '<ui-view></ui-view>'
+        });
+        $stateProvider.state('settings.list', {
+            url: '',
+            template: '<ase-settings-list></ase-settings-list>'
+        });
+    }
+
+    angular
+      .module('ase.views.settings', [
+        'ui.router',
+        'ui.bootstrap',
+        'ase.utils',
+        'ase.config',
+        'ase.directives',
+        'ase.notifications',
+        'ase.views.sidebar',
+        'ase.auth'
+      ]).config(StateConfig);
+
+})();

--- a/app/scripts/views/sidebar/cancel-bubble-directive.js
+++ b/app/scripts/views/sidebar/cancel-bubble-directive.js
@@ -1,0 +1,33 @@
+/**
+ * Attribute directive which cancels upward propagation of click events on that element
+ */
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function CancelBubble($log) {
+        var module = {
+            restrict: 'A',
+            link: link
+        };
+        return module;
+
+        function link(scope, element) {
+
+            element.click(function (event) {
+                // All the cool kids
+                if (event.stopPropagation) {
+                    event.stopPropagation();
+                // IE8 & below
+                } else {
+                    $log.debug('Used cancelBubble in cancel-bubble directive');
+                    event.cancelBubble = true;
+                }
+            });
+        }
+    }
+
+    angular.module('ase.views.sidebar')
+    .directive('cancelBubble', CancelBubble);
+
+})();

--- a/app/scripts/views/sidebar/module.js
+++ b/app/scripts/views/sidebar/module.js
@@ -1,0 +1,21 @@
+(function () {
+    'use strict';
+
+    // TODO: Need to create view hierarchy rather than having this be a top-level view
+
+    /* ngInject */
+    function StateConfig($stateProvider) {
+        $stateProvider.state('sidebar', {
+            abstract: true,
+            url: '',
+            template: '<ase-sidebar></ase-sidebar>'
+        });
+    }
+
+    angular.module('ase.views.sidebar', [
+        'ui.router',
+        'ase.views.recordtype',
+        'ase.views.record'
+    ]).config(StateConfig);
+
+})();

--- a/app/scripts/views/sidebar/sidebar-controller.js
+++ b/app/scripts/views/sidebar/sidebar-controller.js
@@ -1,0 +1,24 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function SidebarController($scope, RecordTypes) {
+        var ctl = this;
+        initialize();
+
+        function initialize() {
+            refreshRecordTypes();
+            $scope.$on('ase.recordtypes.changed', refreshRecordTypes);
+        }
+
+        /*
+         * Queries for an updated set of active record types
+         */
+        function refreshRecordTypes() {
+            ctl.recordTypes = RecordTypes.query({ active: 'True' });
+        }
+    }
+
+    angular.module('ase.views.sidebar')
+    .controller('SidebarController', SidebarController);
+})();

--- a/app/scripts/views/sidebar/sidebar-directive.js
+++ b/app/scripts/views/sidebar/sidebar-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function Sidebar() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/sidebar/sidebar-partial.html',
+            controller: 'SidebarController',
+            controllerAs: 'sb',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.sidebar')
+    .directive('aseSidebar', Sidebar);
+
+})();

--- a/app/scripts/views/sidebar/sidebar-partial.html
+++ b/app/scripts/views/sidebar/sidebar-partial.html
@@ -1,0 +1,25 @@
+<main class="all-record-types">
+    <div class="content-types">
+        <ul>
+            <li class="active-parent in">
+                <a>All Record Types</a>
+                <ul>
+                    <li><a ui-sref="rt.list">View all record types</a></li>
+                    <li><a ui-sref="rt.add">Add a new record type</a>
+                </ul>
+            </li>
+            <li class="active-parent row" ng-repeat="recordType in sb.recordTypes | orderBy:'label'"
+                ng-class="{ 'in': expand }" ng-click="expand = !expand">
+                <a>&#8212; {{ recordType.label }}</a>
+                <ul cancel-bubble>
+                    <li><a ui-sref="rt.related({uuid: '{{recordType.uuid}}'})">View related content</a></li>
+                    <li><a ui-sref="rt.related-add({uuid: '{{recordType.uuid}}'})">Add related content</a></li>
+                    <li><a ui-sref="record.list({recordtype: '{{recordType.uuid}}'})">View records</a></li>
+                    <li><a ui-sref="record.add({recordtype: '{{recordType.uuid}}'})">Add a new record</a></li>
+                </ul>
+            </li>
+        </ul>
+    </div>
+
+    <ui-view></ui-view>
+</main>

--- a/app/scripts/views/usermgmt/add-controller.js
+++ b/app/scripts/views/usermgmt/add-controller.js
@@ -1,0 +1,34 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function UserAddController($log, $state, ASEConfig, AuthService, UserService, Notifications, Utils) {
+        var ctl = this;
+        ctl.user = {};
+        ctl.userGroup = '';
+        ctl.groups = ASEConfig.api.groups;
+
+        ctl.submitForm = function() {
+
+            ctl.user.groups = [ctl.userGroup];
+
+            UserService.User.create(ctl.user, function() {
+                Notifications.show({text: 'User ' + ctl.user.username + ' created successfully',
+                                    displayClass: 'alert-success',
+                                    timeout: 3000});
+                $state.go('usermgmt.list');
+            }, function(error) {
+                $log.error('error creating user:');
+                $log.error(error);
+
+                var errorHtml = '<h4>Failed to create user</h4>';
+                errorHtml += Utils.buildErrorHtml(error);
+
+                Notifications.show({html: errorHtml, displayClass: 'alert-danger'});
+            });
+        };
+    }
+
+    angular.module('ase.views.usermgmt')
+    .controller('UserAddController', UserAddController);
+})();

--- a/app/scripts/views/usermgmt/add-directive.js
+++ b/app/scripts/views/usermgmt/add-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function UserAdd() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/usermgmt/add-partial.html',
+            controller: 'UserAddController',
+            controllerAs: 'UserAdd',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.usermgmt')
+    .directive('aseUserAdd', UserAdd);
+
+})();

--- a/app/scripts/views/usermgmt/add-partial.html
+++ b/app/scripts/views/usermgmt/add-partial.html
@@ -1,0 +1,39 @@
+<div class="form-area edit-user">
+    <div class="col-sm-8 col-sm-offset-3">
+        <ase-notifications></ase-notifications>
+        <div class="form-area-heading">
+            <h2>Create User Account</h2>
+            <div class="content-border"></div>
+        </div>
+        <div class="well">
+            <form name="userForm" ng-submit="UserAdd.submitForm()">
+                <div class="row form-group">
+                    <div class="col-sm-2"><label for="username">Username:</label></div>
+                    <div class="col-sm-4"><input type="text" class="form-control" id="username"
+                        placeholder="Username" required ng-model="UserAdd.user.username"></div>
+                </div>
+                <div class="row form-group">
+                    <div class="col-sm-2"><label for="userEmail">E-mail:</label></div>
+                    <div class="col-sm-4"><input type="email" class="form-control" id="userEmail"
+                        placeholder="Email" ng-model="UserAdd.user.email"></div>
+                </div>
+                <div class="row form-group">
+                    <div class="col-sm-2"><label for="userGroup">User roup:</label></div>
+                    <div class="col-sm-4">
+                        <select required ng-model="UserAdd.userGroup" class="form-control"
+                            id="userGroup" ng-options="group for (groupKey, group) in UserAdd.groups">
+                        </select>
+                    </div>
+                </div>
+                <div class="row form-group">
+                    <div class="col-sm-2"><label for="password">Password:</label></div>
+                    <div class="col-sm-4"><input type="password" class="form-control" id="password"
+                        placeholder="Password" ng-model="UserAdd.user.password"></div>
+                </div>
+                <button type="submit" class="btn btn-default"
+                    ng-disabled="userForm.$invalid">CreateUser</button>
+                <button ui-sref="usermgmt.list" class="btn btn-default">Cancel</button>
+            </form>
+        </div>
+    </div>
+</div>

--- a/app/scripts/views/usermgmt/details-controller.js
+++ b/app/scripts/views/usermgmt/details-controller.js
@@ -1,0 +1,25 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function UserDetailsController($stateParams, AuthService, UserService) {
+        var ctl = this;
+        ctl.user = {};
+        initialize();
+
+        function initialize() {
+            getUserInfo();
+        }
+
+        // Helper for loading the user info
+        function getUserInfo() {
+            UserService.getUser($stateParams.userid).then(function(userInfo) {
+                ctl.user = userInfo;
+                ctl.user.token = AuthService.getToken();
+            });
+        }
+    }
+
+    angular.module('ase.views.usermgmt')
+    .controller('UserDetailsController', UserDetailsController);
+})();

--- a/app/scripts/views/usermgmt/details-directive.js
+++ b/app/scripts/views/usermgmt/details-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function UserDetails() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/usermgmt/details-partial.html',
+            controller: 'UserDetailsController',
+            controllerAs: 'UserDetails',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.usermgmt')
+    .directive('aseUserDetails', UserDetails);
+
+})();

--- a/app/scripts/views/usermgmt/details-partial.html
+++ b/app/scripts/views/usermgmt/details-partial.html
@@ -1,0 +1,43 @@
+<div class="form-area">
+    <div class="col-sm-8 col-sm-offset-3">
+        <ase-notifications></ase-notifications>
+        <div class="form-area-heading">
+            <h2>Details for User Account</h2>
+            <div class="content-border"></div>
+        </div>
+        <div class="well">
+            <div>
+                <div class="row">
+                    <div class="col-sm-2"><label>User ID:</label></div>
+                    <div class="col-sm-4">{{ ::UserDetails.user.id }}</div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-2"><label>E-mail:</label></div>
+                    <div class="col-sm-4">{{ ::UserDetails.user.email }}</div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-2"><label>Administrator?</label></div>
+                    <div class="col-sm-4">
+                        <span ng-show="UserDetails.user.isAdmin">Yes</span>
+                        <span ng-show="!UserDetails.user.isAdmin">No</span>
+                    </div>
+                </div>
+                <div class="row" ng-if="UserDetails.user.groups.length > 0">
+                    <div class="col-sm-2"><label>Groups:</label></div>
+                    <div class="col-sm-4">
+                        <span>{{ ::UserDetails.user.groups.join(', ') }}</span>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-2"><label>Account Created:</label></div>
+                    <div class="col-sm-4">{{ ::UserDetails.user.date_joined | date:'MM/dd/yyyy h:mm a' }}</div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-2"><label>Token:</label></div>
+                    <div class="col-sm-4">{{ ::UserDetails.user.token }}</div>
+                </div>
+            </div>
+        </div>
+        <button ui-sref="usermgmt.list" class="btn btn-default">Go Back</button>
+    </div>
+</div>

--- a/app/scripts/views/usermgmt/edit-controller.js
+++ b/app/scripts/views/usermgmt/edit-controller.js
@@ -1,0 +1,71 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function UserEditController($log, $state, $stateParams, ASEConfig, AuthService, UserService,
+                                Notifications, Utils) {
+        var ctl = this;
+        ctl.user = {};
+        ctl.userGroup = '';
+        ctl.groups = ASEConfig.api.groups;
+        initialize();
+
+        function initialize() {
+            getUserInfo();
+        }
+
+        // Helper for loading the user info
+        function getUserInfo() {
+            UserService.getUser($stateParams.userid).then(function(userInfo) {
+                ctl.user = userInfo;
+                ctl.user.token = AuthService.getToken();
+                ctl.userGroup = getUserGroup();
+            });
+        }
+
+        // Helper to pull out the highest access level group to which the user belongs
+        // (User can belong to multiple groups, but pretend like they are exclusive for the form.)
+        function getUserGroup() {
+            var groupList = ctl.user.groups; // an array of groups to which the user belongs
+
+            if (groupList.indexOf(ASEConfig.api.groups.admin) > -1) {
+                // admin
+                return ASEConfig.api.groups.admin;
+            } else if (groupList.indexOf(ASEConfig.api.groups.readWrite) > -1) {
+                // analyst
+                return ASEConfig.api.groups.readWrite;
+            }
+
+            // default to public
+            return ASEConfig.api.groups.readOnly;
+        }
+
+        ctl.submitForm = function() {
+            // submit just the data that may have changed
+            var patchUser = {
+                username: ctl.user.username,
+                email: ctl.user.email,
+                groups: [ctl.userGroup]
+            };
+
+            UserService.User.update({id: ctl.user.id}, patchUser, function() {
+                getUserInfo();
+                Notifications.show({text: 'Successfully updated user ' + ctl.user.email,
+                                   displayClass: 'alert-success',
+                                   timeout: 3000});
+                $state.go('usermgmt.list');
+            }, function(error) {
+                $log.error('error updating user:');
+                $log.error(error);
+
+                var errorHtml = '<h4>Failed to modify user</h4>';
+                errorHtml += Utils.buildErrorHtml(error);
+
+                Notifications.show({html: errorHtml, displayClass: 'alert-danger'});
+            });
+        };
+    }
+
+    angular.module('ase.views.usermgmt')
+    .controller('UserEditController', UserEditController);
+})();

--- a/app/scripts/views/usermgmt/edit-directive.js
+++ b/app/scripts/views/usermgmt/edit-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function UserEdit() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/usermgmt/edit-partial.html',
+            controller: 'UserEditController',
+            controllerAs: 'UserEdit',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.usermgmt')
+    .directive('aseUserEdit', UserEdit);
+
+})();

--- a/app/scripts/views/usermgmt/edit-partial.html
+++ b/app/scripts/views/usermgmt/edit-partial.html
@@ -1,0 +1,42 @@
+<div class="form-area edit-user">
+    <div class="col-sm-8 col-sm-offset-3">
+        <ase-notifications></ase-notifications>
+        <div class="form-area-heading">
+            <h2>Modify User Account</h2>
+            <div class="content-border"></div>
+        </div>
+        <div class="well">
+            <form name="userForm" ng-submit="UserEdit.submitForm()">
+                <div class="row form-group">
+                    <div class="col-sm-2"><label for="username">Username:</label></div>
+                    <div class="col-sm-4"><input type="text" class="form-control" id="username"
+                        placeholder="Username" required ng-model="UserEdit.user.username"></div>
+                </div>
+                <div class="row form-group">
+                    <div class="col-sm-2"><label for="userEmail">E-mail:</label></div>
+                    <div class="col-sm-4"><input type="email" class="form-control" id="userEmail"
+                        placeholder="Email" ng-model="UserEdit.user.email"></div>
+                </div>
+                <div class="row form-group">
+                    <div class="col-sm-2"><label for="userGroup">User group:</label></div>
+                    <div class="col-sm-4">
+                        <select required ng-model="UserEdit.userGroup" class="form-control"
+                            id="userGroup" ng-options="group for (groupKey, group) in UserEdit.groups">
+                        </select>
+                    </div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-2"><label>User ID:</label></div>
+                    <div class="col-sm-4">{{ UserEdit.user.id }}</div>
+                </div>
+                <div class="row">
+                    <div class="col-sm-2"><label>Token:</label></div>
+                    <div class="col-sm-4">{{ UserEdit.user.token }}</div>
+                </div>
+                <button type="submit" class="btn btn-default"
+                    ng-disabled="userForm.$invalid">Save Changes</button>
+                <button ui-sref="usermgmt.list" class="btn btn-default">Cancel</button>
+            </form>
+        </div>
+    </div>
+</div>

--- a/app/scripts/views/usermgmt/list-controller.js
+++ b/app/scripts/views/usermgmt/list-controller.js
@@ -1,0 +1,59 @@
+(function() {
+    'use strict';
+
+    /**
+     * @ngInject
+     */
+    function UserListController ($log, $scope, Notifications, UserService, ASEConfig) {
+
+        var ctl = this;
+        initialize();
+
+        function initialize() {
+            ctl.users = {};
+            ctl.groups = _.values(ASEConfig.api.groups).sort();
+            ctl.groupFilter = null;
+
+            ctl.deleteUser = deleteUser;
+            ctl.onGroupSelected = onGroupSelected;
+
+            refreshUserList();
+        }
+
+        function deleteUser(user) {
+            UserService.User.delete({id: user.id}, function () {
+                refreshUserList();
+
+                Notifications.show({text: 'Deleted user ' + user.username + ' successfully.',
+                                    displayClass: 'alert-success',
+                                    timeout: 3000});
+            }, function(error) {
+                $log.error(error);
+
+                Notifications.show({text: 'Error deleting user ' + user.email,
+                                   displayClass: 'alert-danger'});
+            });
+        }
+
+        function filterUserList() {
+            ctl.users = _.filter(ctl.allUsers, function (user) {
+                return !ctl.groupFilter || _.contains(user.groups, ctl.groupFilter);
+            });
+        }
+
+        function refreshUserList() {
+            UserService.User.query().$promise.then(function (results) {
+                ctl.allUsers = results;
+                filterUserList();
+            });
+        }
+
+        function onGroupSelected(group) {
+            ctl.groupFilter = group;
+            filterUserList();
+        }
+    }
+
+    angular.module('ase.views.usermgmt').controller('UserListController', UserListController);
+
+})();

--- a/app/scripts/views/usermgmt/list-directive.js
+++ b/app/scripts/views/usermgmt/list-directive.js
@@ -1,0 +1,19 @@
+(function () {
+    'use strict';
+
+    /* ngInject */
+    function UserList() {
+        var module = {
+            restrict: 'E',
+            templateUrl: 'scripts/views/usermgmt/list-partial.html',
+            controller: 'UserListController',
+            controllerAs: 'UserList',
+            bindToController: true
+        };
+        return module;
+    }
+
+    angular.module('ase.views.usermgmt')
+    .directive('aseUserList', UserList);
+
+})();

--- a/app/scripts/views/usermgmt/list-partial.html
+++ b/app/scripts/views/usermgmt/list-partial.html
@@ -1,0 +1,58 @@
+<div class="form-area">
+    <div class="col-sm-8 col-sm-offset-3">
+        <ase-notifications></ase-notifications>
+        <div class="form-area-heading">
+            <h2>All Users</h2>
+            <div class="button-container">
+                <div class="dropdown">
+                    <button class="dropdown-toggle btn btn-default" data-toggle="dropdown" role="button">
+                        {{ UserList.groupFilter ? 'Group: ' + UserList.groupFilter : 'Filter by group...' }}
+                        <span class="caret"></span></button>
+                    <ul class="dropdown-menu">
+                        <li><a ng-click="UserList.onGroupSelected(null)">All</a></li>
+                        <li ng-repeat="group in UserList.groups">
+                            <a ng-click="UserList.onGroupSelected(group)">
+                                {{ group }}
+                            </a>
+                        </li>
+                    </ul>
+                </div>
+                <button type="button" ui-sref="usermgmt.add" class="btn btn-default">Add new user</button>
+            </div>
+            <div class="content-border"></div>
+        </div>
+        <div class="form-area-body">
+            <div ng-repeat="user in UserList.users" class="row">
+                <div class="type">
+                    <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 10 22" enable-background="new 0 0 10 22" xml:space="preserve">
+                        <path opacity="0.5" fill-rule="evenodd" clip-rule="evenodd" fill="#4A4A4A" d="M4.6,20.6L8,17.3H1.3L4.6,20.6z M1.3,4H8L4.6,0.7 L1.3,4z M8,10.7c0-1.8-1.5-3.3-3.3-3.3c-1.8,0-3.3,1.5-3.3,3.3c0,1.8,1.5,3.3,3.3,3.3C6.5,14,8,12.5,8,10.7z"/>
+                    </svg>
+                    <h4>
+                      <a ui-sref="usermgmt.edit({ userid: user.id })">{{ ::user.email }}</a>
+                    </h4>
+                    <a ui-sref="usermgmt.details({ userid: user.id })" role="button" class="edit">
+                        <p>Details</p>
+                        <svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 95 100" enable-background="new 0 0 80 100" xml:space="preserve">
+                            <polygon points="92.901,35.938 90.089,12.031 67.427,21.513 76.354,26.566 56.799,61.33 43.643,46.857 7.099,87.969 20.268,87.969 43.724,61.58 58.693,78.045 84.92,31.418"/>
+                        </svg>
+                    </a>
+                    <a ase-confirm-click="UserList.deleteUser(user)"
+                       role="button" class="delete">
+                        <p>Delete</p>
+                        <svg version="1.1" id="Layer_2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 80 100" enable-background="new 0 0 80 100" xml:space="preserve">
+                            <path d="M6.1,39l5.5,48.5c0.3,2.3,11.4,9.9,27.5,9.9c16.1,0,27.3-7.6,27.6-9.9L72.2,39c-8.4,4.7-21,6.9-33.1,6.9 C27.1,46,14.5,43.7,6.1,39z M55,9l-4.3-4.8c-1.7-2.4-3.5-2.8-7-2.8h-9.2c-3.5,0-5.3,0.4-7,2.8L23.4,9C10.5,11.3,1.2,17.2,1.2,21.6 v0.9c0,7.7,17,14,38,14c21,0,38-6.3,38-14v-0.9C77.2,17.2,67.9,11.3,55,9z M49.5,20.2l-6.3-6.7h-8.2l-6.3,6.7h-8.5 c0,0,9.3-11.1,10.6-12.6c1-1.2,1.9-1.6,3.2-1.6h10.2c1.3,0,2.2,0.4,3.2,1.6C48.7,9.1,58,20.2,58,20.2H49.5z"/>
+                        </svg>
+                    </a>
+                    <a ui-sref="usermgmt.edit({ userid: user.id })" role="button" class="edit">
+                        <p>Edit</p>
+                        <svg version="1.1" id="Layer_3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+                        viewBox="0 0 80 80" enable-background="new 0 0 80 80" xml:space="preserve">
+                            <g><path d="M71.8,8.2C64.6,1,59.2,2.1,59.2,2.1L33.9,27.3L5,56.2L0,80l23.8-5.1l28.9-28.9l25.3-25.3C77.9,20.8,79,15.4,71.8,8.2z M22.4,72.1l-8.1,1.7c-0.8-1.5-1.7-2.9-3.5-4.7c-1.7-1.7-3.2-2.7-4.7-3.5l1.8-8.1l2.3-2.3c0,0,4.4,0.1,9.4,5.1c5,5,5.1,9.4,5.1,9.4 L22.4,72.1z"/></g>
+                        </svg>
+                    </a>
+                </div>
+            </div>
+            <div class="dark-border"></div>
+        </div>
+    </div>
+</div>

--- a/app/scripts/views/usermgmt/module.js
+++ b/app/scripts/views/usermgmt/module.js
@@ -1,0 +1,47 @@
+(function () {
+'use strict';
+
+    /**
+     * @ngInject
+     */
+    function StateConfig($stateProvider) {
+
+        $stateProvider.state('usermgmt', {
+            abstract: true,
+            parent: 'sidebar',
+            url: '/user-management',
+            template: '<ui-view></ui-view>'
+        });
+        $stateProvider.state('usermgmt.list', {
+            url: '',
+            template: '<ase-user-list></ase-user-list>'
+        });
+
+        $stateProvider.state('usermgmt.add', {
+            url: '/add',
+            template: '<ase-user-add></ase-user-add>'
+        });
+        $stateProvider.state('usermgmt.edit', {
+            url: '/edit/:userid',
+            template: '<ase-user-edit></ase-user-edit>'
+        });
+        $stateProvider.state('usermgmt.details', {
+            url: '/details/:userid',
+            template: '<ase-user-details></ase-user-details>'
+        });
+    }
+
+    angular
+      .module('ase.views.usermgmt', [
+        'ui.router',
+        'ui.bootstrap',
+        'ase.utils',
+        'ase.config',
+        'ase.directives',
+        'ase.notifications',
+        'ase.views.sidebar',
+        'ase.auth',
+        'ase.userdata'
+      ]).config(StateConfig);
+
+})();

--- a/app/styles/_layout.scss
+++ b/app/styles/_layout.scss
@@ -1,0 +1,101 @@
+body {
+	font-weight: 300;
+}
+
+
+h5 {
+	text-transform: uppercase;
+	color: #555;
+
+}
+
+a {
+	text-decoration: none;
+	color: #000;
+	&:hover {
+		text-decoration: none;
+		color: #999;
+	}
+}
+
+
+svg {
+	width: 15px;
+}
+
+.btn {
+	border-radius: 20px;
+}
+
+label {
+	text-transform: uppercase;
+	font-size: 12px;
+	color: #555;
+    :not(.acct-info) {
+        margin-top: 10px;
+    }
+}
+
+.checkbox label {
+	text-transform: initial;
+	margin-top: 5px;
+}
+
+.row {
+	margin-left: 0;
+	margin-right: 0;
+}
+
+.acct-info {
+    .row {
+        margin-top: 10px;
+    }
+}
+
+/* MAIN BODY */
+
+.form-area {
+	position: relative;
+	padding-top: 80px;
+}
+
+/* MAIN BODY HEADING */
+
+.content-border {
+	border-bottom: 3px solid #dedede;
+	margin-bottom: 20px;
+}
+
+.form-area-heading {
+	.button-container {
+		float: right;
+		margin-top: -40px;
+
+        .btn, .dropdown {
+            float: left;
+            margin-left: 5px;
+        }
+	}
+}
+
+.edit, .delete {
+	color: #000;
+	fill: #000;
+
+	&:hover {
+		color: #999;
+		fill: #999;
+
+	}
+}
+
+/* SAVE BUTTON AREA */
+
+.save-area {
+	margin: 25px 39%;
+	display: inline-block;
+	.btn {
+		margin-right: 15px;
+	}
+}
+

--- a/app/styles/_mixins.scss
+++ b/app/styles/_mixins.scss
@@ -1,0 +1,22 @@
+@mixin close-modal {
+    position: absolute;
+    right: -15px;
+    top: -15px;
+    background: white;
+    padding: 8px;
+    opacity: 1;
+    box-shadow: 0 0 5px rgba(0,0,0,0.25);
+    width: 30px;
+    height: 30px;
+    line-height: 0.6;
+    text-align: center;
+    border-radius: 999px;
+    color: #999;
+    transition: 0.5s all;
+
+    &:hover {
+        color: #000;
+        box-shadow: 0 0 5px rgba(0,0,0,0.45);
+    }
+}
+

--- a/app/styles/main.scss
+++ b/app/styles/main.scss
@@ -1,0 +1,20 @@
+$icon-font-path: "../bower_components/bootstrap-sass-official/assets/fonts/bootstrap/";
+// bower:scss
+@import "bootstrap-sass-official/assets/stylesheets/_bootstrap.scss";
+// endbower
+
+@import "layout";
+@import "mixins";
+
+@import "partials/json-editor";
+@import "partials/nav";
+@import "partials/field";
+@import "partials/map";
+@import "partials/map-view";
+@import "partials/types";
+@import "partials/add-new";
+@import "partials/edit-user";
+@import "partials/notifications";
+@import "partials/table-view";
+@import "partials/incident-report";
+

--- a/app/styles/partials/_add-new.scss
+++ b/app/styles/partials/_add-new.scss
@@ -1,0 +1,45 @@
+.add-new {
+	form {
+		background-color: transparent;
+	}
+
+	input[type="file"] {
+		text-align: right;
+	}
+
+    map {
+        height:300px;
+    }
+
+/* background-image in select doesn't work in Chrome */
+
+	select#boundary-color option[value="Red"] {
+		background-image: url(red.png);
+		background-repeat: no-repeat;
+		background-position: bottom left;
+		padding-left: 30px;
+	}
+
+	select#boundary-color option[value="Blue"] {
+		background-image: url(blue.png);
+		background-repeat: no-repeat;
+		background-position: bottom left;
+		padding-left: 30px;
+	}
+
+	select#boundary-color option[value="Green"] {
+		background-image: url(green.png);
+		background-repeat: no-repeat;
+		background-position: bottom left;
+		padding-left: 30px;
+	}
+
+}
+
+.input-group-addon.picker {
+    cursor: pointer;
+}
+
+.constant-fields .date-picker {
+    margin-top: 20px !important;
+}

--- a/app/styles/partials/_edit-user.scss
+++ b/app/styles/partials/_edit-user.scss
@@ -1,0 +1,5 @@
+.edit-user {
+    form {
+        background-color: transparent;
+    }
+}

--- a/app/styles/partials/_field.scss
+++ b/app/styles/partials/_field.scss
@@ -1,0 +1,70 @@
+/* FIELD HEADING */
+
+.field {
+	border-top: 3px solid #fff;
+	background-color: #efefef;
+	padding: 15px;
+
+	h4, h5, svg, p {
+		display: inline;
+	}
+
+	p, svg {
+		float: right;
+	}
+
+	p {
+		margin-left: 5px;
+		margin-right: 30px;
+	}
+
+	.btn-group {
+		margin: 10px 40%;
+	}
+}
+
+
+/* FIELD OPTIONS */
+
+.field-type-options, form {
+    background-color: #efefef;
+    margin-bottom: -10px;
+}
+
+.field-type-options {
+    padding-bottom: 20px;
+}
+
+.form-collapse {
+	border-top: 2px solid #ddd;
+	max-height: 0;
+	overflow: hidden;
+	transition: 0.25s max-height;
+	&.active {
+		max-height: 600px;
+	}
+}
+
+/*.form-collapse-2 {
+	border-top: 1px solid #ddd;
+}*/
+
+.form-horizontal .control-label {
+	text-align: left;
+}
+
+.date-picker {
+    .dropdown-menu {
+        table {
+            button {
+                border: none;
+            }
+        }
+    }
+}
+
+select[ng-model="ctl.weather"] {
+    & + span > .wi {
+        width: 18px;
+    }
+}

--- a/app/styles/partials/_incident-report.scss
+++ b/app/styles/partials/_incident-report.scss
@@ -1,0 +1,187 @@
+.incident-report {
+
+    &.single {
+        margin: 40px 0 20px;
+
+        @media print {
+            margin: 0;
+
+            label {
+                font-size: 10px;
+            }
+
+            .col-sm-2 {
+                width: 15%;
+                display: inline-block;
+            }
+            .col-sm-3 {
+                width: 24%;
+                display: inline-block;
+            }
+            .col-sm-5 {
+                width: 41%;
+                display: inline-block;
+            }
+            .col-sm-6 {
+                width: 48%;
+                display: inline-block;
+            }
+            .alert,
+            .btn {
+                display: none;
+            }
+        }
+
+        .report-header {
+            margin: 0;
+            padding: 0 0 15px;
+            border-bottom: 5px solid #ddd;
+        }
+        .report-content {
+            padding-top: 0;
+
+            h2 {
+                background: $light-gray;
+                padding: 12px 16px;
+
+                @media print {
+                    padding: 10px 0;
+                }
+            }
+        }
+    }
+    &.modal {
+        background: rgba(0,0,0,0.5);
+    }
+
+    .modal-content {
+        border-radius: 0;
+        border: none;
+        padding: 15px;
+    }
+    .modal-footer {
+        margin: 15px -15px -15px;
+    }
+    .edit {
+        font-size: 14px;
+        font-weight: 700;
+        
+        .glyphicon { font-size: 12px; margin-right: 3px; }
+    }
+    .close {
+        @include close-modal();
+    }
+    .alert {
+        margin: 15px 0 0;
+    }
+
+    .report-header {
+        border-bottom: 1px solid #ddd;
+        margin: 0 -15px 0 -15px;
+        padding: 0 15px 15px;
+
+        h1 {
+            font-size: 30px;
+            font-weight: 400;
+            margin: 0;
+
+            small {
+                margin-left: 5px;
+                font-size: 18px;
+                font-weight: 700;
+                color: #AAA;
+            }
+        }
+        h3 small {
+            margin-left: 10px;
+            
+            a {
+                font-weight: 700;
+                text-decoration: underline;
+            }
+        }
+    }
+    .report-sections {
+        margin: 0 -15px;
+        background-color: $light-gray;
+        padding: 5px 8px 0;
+
+        a { font-weight: 700; }
+    }
+    .report-content {
+        padding-top: 25px;
+
+        h2 {
+            margin: 0 0 20px;
+            padding-bottom: 8px;
+            border-bottom: 1px solid #ddd;
+            font-size: 24px;
+            font-weight: 400;
+
+            .edit {
+                margin-top: 12px;
+            }
+        }
+        hr {
+            margin: 30px 0;
+
+            @media print {
+                margin: 20px 0;
+            }
+        }
+    }
+    .map {
+        height: 300px;
+        margin-bottom: 10px;
+    }
+
+    .table {
+        .table-head {
+            padding: 10px;
+            font-weight: 700;
+            text-transform: uppercase;
+            font-size: 12px;
+            color: #AAA;
+            border-bottom: 4px solid #ddd;
+
+            @media print {
+                font-size: 10px;
+                padding: 10px 0;
+            }
+        }
+        .table-body {
+            .table-body-row {
+                .table-body-row-header {
+                    padding: 10px;
+                    border-bottom: 1px solid #ddd;
+                    cursor: pointer;
+
+                    @media print {
+                        padding: 10px 0;
+                    }
+
+                    &.open {
+                        background-color: $light-gray;
+
+                        & + .table-body-row-content {
+                            max-height: 1000px;
+                            padding: 20px 15px;
+                            border-bottom: 1px solid #ddd;
+
+                            @media print {
+                                padding: 10px 0;
+                            }
+                        }
+                    }
+                }
+                .table-body-row-content {
+                    height: auto;
+                    max-height: 0;
+                    overflow: hidden;
+                    padding: 0;
+                    transition: 0.5 all;
+                }
+            }
+        }
+    }
+}

--- a/app/styles/partials/_json-editor.scss
+++ b/app/styles/partials/_json-editor.scss
@@ -1,0 +1,112 @@
+.json-editor-form {
+
+    .form-group {
+        margin-top: 10px;
+    }
+    .save-area {
+        display: block;
+        position: fixed;
+        top: 175px;
+        max-width: 250px;
+        margin: 0 auto;
+    }
+
+    json-editor {
+        > div > h3 {
+            display: none;
+        }
+
+        > div > .well {
+            background: none;
+            border: none;
+            padding: 0;
+            box-shadow: none;
+        
+            > div > div > .row {
+                margin: 0;
+
+                > div {
+                    min-height: 20px;
+                    padding: 19px;
+                    margin-bottom: 20px;
+                    background-color: #f5f5f5;
+                    border: 1px solid #e3e3e3;
+                    border-radius: 0px;
+                    box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+
+                    > h3 {
+                        margin-bottom: 0;
+
+                        .btn-group {
+                            float: right;
+                        }
+                        span {
+                            top: 3px;
+                            position: relative;
+                        }
+                        
+                        + p {
+                            display: none;
+                        }
+                    }
+
+                    &[data-schematype="array"] {
+                        > .well.well-sm {
+                            margin-top: 15px;
+                            border: 1px solid #e3e3e3;
+                            background: white;
+                            
+                            > .btn-group {
+                                padding: 15px;
+                                text-align: center;
+                            }
+                            > div > [data-schematype="object"] {
+                                h3 {
+                                    padding: 15px;
+                                    font-size: 18px;
+                                    font-weight: 400;
+                                    border-bottom: 1px solid #CCC;
+                                    height: 65px;
+                                    margin-bottom: 0;
+
+                                    span {
+                                        position: relative;
+                                        top: 8px;
+                                    }
+                                    .btn-group { 
+                                        float: right; 
+                                    }
+                                    + p { 
+                                        display: none; 
+                                    }
+                                }
+                                .well.well-sm {
+                                    margin: 0;
+                                    padding: 15px;
+                                    border-bottom: 1px solid #CCC;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    .well {
+        border-radius: 0;
+    }
+    .map {
+        height:300px;
+    }
+    
+    h3 {
+        margin-top: 0;
+    }
+    label.required {
+        &:after {
+            content: ' *';
+        }
+    }
+
+}

--- a/app/styles/partials/_map-view.scss
+++ b/app/styles/partials/_map-view.scss
@@ -1,0 +1,141 @@
+$light-gray: #f1f2f2;
+
+.map-view {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    width: 100%;
+
+    #map {
+        background: $light-gray;
+        position: absolute;
+        top: 52px;
+        bottom: 0;
+        width: 100%;
+    }
+
+    .tools {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+
+        .tool {
+            position: relative;
+            margin-left: 10px;
+            display: inline-block;
+
+            &:first-of-type {
+                margin-left: 20px;
+            }
+
+            &.open {
+                .tool-tab {
+                    bottom: -2px;
+                    padding-top: 20px;
+                }
+                .tool-content {
+                    max-height: 300px;
+                }
+            }
+            .tool-tab {
+                background: white;
+                padding: 16px 20px 16px;
+                position: relative;
+                bottom: -2px;
+                transition: 0.5s all;
+                cursor: pointer;
+            }
+            .tool-content {
+                width: 600px;
+                background: white;
+                max-height: 0;
+                bottom: 50px;
+                overflow: hidden;
+                position: absolute;
+                transition: 0.5s all;
+            }
+            .tool-header {
+                margin: 20px 15px 0 15px;
+            }
+            .tool-body {
+            }
+            .tool-item {
+                padding: 15px;
+                border-bottom: 1px solid #eeeeee;
+                &.clickable {
+                    cursor: pointer;
+                }
+                a {
+                    color: inherit;
+                }
+            }
+            .cube-grid-spinner {
+                width: 15px;
+                height: 15px;
+                margin: 0px 0px -2px 0px;
+                display: inline-block;
+            }
+            .error {
+                cursor: default;
+            }
+
+            &.graphs {
+                .tool-content {
+                    width: 600px;
+                    height: 300px;
+                }
+                .tool-body {
+                    margin: 25px 15px 20px 15px;
+                    padding: 0px;
+                    height: 200px;
+                    driver-stepwise {
+                        height: 200px;
+                        width: 570px;
+                        display: block;
+                        overflow: visible;
+                    }
+                }
+            }
+            &.enforcers {
+                .tool-content {
+                    width: 300px;
+                }
+            }
+            &.export {
+                .tool-content {
+                    width: 200px;
+                }
+            }
+            &.interventions {
+                .tool-content {
+                    width: 215px;
+                }
+            }
+            &.costs {
+                .tool-content {
+                    width: 400px;
+                    font-size: 16px;
+                    .subtotal {
+                        border-collapse: separate;
+                        border-spacing: 20px;
+                    }
+                }
+            }
+
+            .graph-selector {
+                cursor: pointer;
+                color: lightgrey;
+                border: 2px solid #d3d3d3;
+                border-radius: 99px;
+                padding: 8px;
+                top: -8px;
+
+                &.active {
+                    color: black;
+                    border-color: #000;
+                }
+            }
+        }
+    }
+}

--- a/app/styles/partials/_map.scss
+++ b/app/styles/partials/_map.scss
@@ -1,0 +1,72 @@
+.records-map, driver-map {
+	position: fixed;
+    top: 102px;
+    width: 100%;
+    bottom: 0;
+}
+
+.leaflet-control-layers-expanded {
+    
+    label {
+        margin-top: 4px;
+    }
+
+    .leaflet-control-layers-base label {
+        margin-top: 0;
+    }
+    .leaflet-control-layers-list {
+        background: none;
+        padding: 5px 5px 10px;
+    }
+    .leaflet-control-layers-separator {
+        margin: 5px -15px 10px -11px;
+    }
+
+    input[type=checkbox], input[type=radio] {
+        margin-right: 5px;
+        top: -1px;
+    }
+}
+.leaflet-popup {
+    .leaflet-popup-content {
+        margin: 20px 20px 25px;
+    }
+    .leaflet-popup-content-wrapper {
+        border-radius: 0;
+
+        h5 {
+            font-size: 12px;
+            font-weight: 700;
+            color: #aaa;
+            margin: 0;
+        }
+        h3 {
+            margin: 8px 0 25px;
+            font-weight: 300;
+        }
+        a {
+            font-weight: 700;
+            font-size: 12px;
+            border: 1px solid #ccc;
+            padding: 4px 10px;
+            border-radius: 99px;
+            margin-right: 8px;
+            color: #333;
+            cursor: pointer;
+    
+            span { margin-right: 3px; }
+    
+            &:hover {
+                color: #333;
+                background-color: #e6e6e6;
+                border-color: #adadad;
+            }
+        }
+    }
+    .leaflet-popup-close-button {
+        padding: 10px 20px 0 0 !important;
+        text-align: center;
+        width: 22px;
+        height: 24px;
+    }
+}

--- a/app/styles/partials/_nav.scss
+++ b/app/styles/partials/_nav.scss
@@ -1,0 +1,68 @@
+.navbar-default {
+	position: fixed;
+	z-index: 10;
+	width: 100%;
+}
+
+.content-types {
+	position: fixed;
+	width: 220px;
+	height: 100%;
+	background-color: #555;
+	margin-top: 50px;
+	z-index: 9;
+
+	> ul {
+		padding-left: 0;
+
+		> li {
+			color: #fff;
+			list-style-type: none;
+			
+			border-bottom: 1px solid #777;
+
+			a {
+				font-size: 14px;
+				color: #AAA;
+				padding: 12px 16px;
+				display: block;
+                cursor: pointer;
+
+				&:hover {
+					text-decoration: none;
+					color: #FFF;
+					background-color: #666;
+				}
+			}
+
+			> ul {
+				overflow: hidden;
+				max-height: 0;
+                transition: 0.5s max-height;
+                list-style-type: none;
+                padding-left: 0;
+
+                a {
+                    padding-left: 40px;
+                
+                    &:hover {
+                        background-color: #666;
+                    }
+                }
+			}
+
+			&.in > ul {
+				max-height: 400px;
+			}
+		}
+	}
+
+	.active-parent > a {
+		color: #fff !important;
+        background: #333;
+	}
+	.active-page > a {
+		color: #fff;
+        background: #444;
+	}
+}

--- a/app/styles/partials/_notifications.scss
+++ b/app/styles/partials/_notifications.scss
@@ -1,0 +1,7 @@
+.glyphicon-remove {
+	cursor: pointer;
+}
+
+.glyphicon {
+    margin: 5px;
+}

--- a/app/styles/partials/_table-view.scss
+++ b/app/styles/partials/_table-view.scss
@@ -1,0 +1,78 @@
+$light-gray: #f1f2f2;
+
+.table-view {
+    background: $light-gray;
+    bottom: 0;
+    width: 100%;
+    top: 0;
+
+    &.custom-report {
+        // Custom report uses table-view without table-view-container, because it scrolls
+        // the whole page so the absolute-positioned gray background breaks things.
+        background: white;
+        margin-top: 50px;
+        padding: 0px 20px;
+
+        td:nth-child(even) {
+            background: $light-gray;
+        }
+    }
+
+    .table-view-container {
+        margin: 60px;
+        background: white;
+        bottom: 0;
+        top: 0;
+        left: 0;
+        right: 0;
+
+
+        .links {
+            text-align: right;
+
+            a {
+                font-weight: 700;
+                font-size: 12px;
+                border: 1px solid #ccc;
+                padding: 4px 10px;
+                border-radius: 99px;
+                margin-left: 8px;
+
+                span { margin-right: 3px; }
+
+                &:hover {
+                    color: #333;
+                    background-color: #e6e6e6;
+                    border-color: #adadad;
+                }
+            }
+        }
+    }
+    .overflow {
+        width: 100%;
+        top: 0;
+        bottom: 0;
+        overflow: auto;
+
+        nav {
+            position: relative;
+            padding: 0 20px;
+        }
+    }
+    .table {
+        margin: 0;
+
+        th {
+            background: #ddd;
+            font-size: 12px;
+            font-weight: 700;
+            text-transform: uppercase;
+        }
+
+        caption {
+            text-align: left;
+            margin: 10px;
+            font-size: 18px;
+        }
+    }
+}

--- a/app/styles/partials/_types.scss
+++ b/app/styles/partials/_types.scss
@@ -1,0 +1,33 @@
+.all-record-types {
+
+    #Layer_1 {
+    	float: left;
+    	width: 12px;
+    }
+
+    .type {
+    	border-top: 3px solid #fff;
+    	border-bottom: 1px solid #DDD;
+    	padding: 15px;
+    	background-color: #fff;
+
+
+    	h4 {
+    		margin-left: 16px;
+            margin-top: 2px;
+    		border-bottom: 1px solid #000;
+    	}
+
+    	h4, h5, svg, p {
+    		display: inline;
+    	}
+
+    	p, svg {
+    		float: right;
+    	}
+    	p {
+    		margin-left: 5px;
+    		margin-right: 30px;
+    	}
+    }
+}

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,33 @@
+{
+  "name": "ase",
+  "version": "0.0.0",
+  "dependencies": {
+    "angular": "~1.5.8",
+    "angular-bootstrap-datetimepicker-directive": "~0.1.3",
+    "bootstrap-sass-official": "twbs/bootstrap-sass#02c61388626f6942a8bcbb2129866a976b093acb",
+    "angular-animate": "~1.5.8",
+    "angular-aria": "~1.5.8",
+    "angular-cookies": "~1.5.8",
+    "ng-file-upload": "^4.0.0",
+    "angular-spinkit": "^0.3.3",
+    "angular-resource": "~1.5.8",
+    "angular-sanitize": "~1.5.8",
+    "angular-ui-router": "~0.2.14",
+    "angular-uuids": "~0.0.4",
+    "json-editor": "azavea/json-editor#v10.7.25",
+    "angular-local-storage": "~0.2.2",
+    "angular-bootstrap": "~0.13.0",
+    "lodash": "^3.8.0",
+    "moment": "2.13.0",
+    "moment-timezone": "0.5.6",
+    "leaflet": "~0.7.3",
+    "world-calendars": "azavea/calendars#master"
+  },
+  "devDependencies": {
+    "angular-mocks": "~1.5.8",
+    "jjv": "~1.0.2",
+    "karma-read-json": "~1.1.0"
+  },
+  "appPath": "app",
+  "moduleName": "aseApp"
+}

--- a/bower_components
+++ b/bower_components
@@ -1,0 +1,1 @@
+/bower/bower_components

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/npm/node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "ase",
+  "version": "1.1.1",
+  "dependencies": {},
+  "repository": {},
+  "devDependencies": {
+    "connect-modrewrite": "~0.8.2",
+    "grunt": "^0.4.5",
+    "grunt-autoprefixer": "^2.0.0",
+    "grunt-concurrent": "^1.0.0",
+    "grunt-contrib-clean": "^0.6.0",
+    "grunt-contrib-compass": "^1.0.0",
+    "grunt-contrib-concat": "^0.5.0",
+    "grunt-contrib-connect": "^0.9.0",
+    "grunt-contrib-copy": "^0.7.0",
+    "grunt-contrib-cssmin": "^0.12.0",
+    "grunt-contrib-htmlmin": "^0.4.0",
+    "grunt-contrib-imagemin": "^0.9.2",
+    "grunt-contrib-jshint": "^0.11.0",
+    "grunt-contrib-uglify": "^0.7.0",
+    "grunt-contrib-watch": "^0.6.1",
+    "grunt-filerev": "^2.1.2",
+    "grunt-google-cdn": "^0.4.3",
+    "grunt-karma": "*",
+    "grunt-newer": "^1.1.0",
+    "grunt-ng-annotate": "^0.9.2",
+    "grunt-svgmin": "^2.0.0",
+    "grunt-usemin": "~3.0.0",
+    "grunt-wiredep": "^2.0.0",
+    "jshint-stylish": "^1.0.0",
+    "karma-jasmine": "*",
+    "karma-ng-html2js-preprocessor": "^0.1.2",
+    "karma-phantomjs-launcher": "*",
+    "load-grunt-tasks": "^3.1.0",
+    "time-grunt": "^1.0.0"
+  },
+  "engines": {
+    "node": ">=0.10.0"
+  },
+  "scripts": {
+    "test": "grunt test"
+  }
+}

--- a/scripts/_config.sh
+++ b/scripts/_config.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+#
+# _config.sh -- common config settings for dev scripts
+
+# If an unhandled command returns a non-zero exit code, stop the script.
+set -e
+
+# If the user has set the ASHLAR_DEBUG variable to any value, run
+# this script in debug mode (print all commands before they run).
+if [[ -n "${ASHLAR_DEBUG}" ]]; then
+    set -x
+fi
+
+# Trap Ctrl+C signals and make sure they kill all running containers.
+trap "docker-compose stop" SIGINT SIGTERM

--- a/scripts/clean
+++ b/scripts/clean
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Most reliable way to get the path for this script.
+# h/t: https://stackoverflow.com/questions/192292/bash-how-best-to-include-other-scripts/12694189#12694189
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]];
+then
+    DIR="$PWD"
+fi
+
+# Load common configs for this script.
+source "${DIR}/_config.sh"
+
+function usage() {
+    echo -n "Usage: $(basename "$0")
+
+Clean up unused Docker resources to free disk space.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${1:-}" = "--help" ]; then
+        usage
+    else
+        # Remove unused containers, images, and volumes
+        docker system prune -f
+    fi
+fi

--- a/scripts/test
+++ b/scripts/test
@@ -1,0 +1,86 @@
+#!/bin/bash
+
+# Most reliable way to get the path for this script.
+# h/t: https://stackoverflow.com/questions/192292/bash-how-best-to-include-other-scripts/12694189#12694189
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]];
+then
+    DIR="$PWD"
+fi
+
+# Load common configs for this script.
+source "${DIR}/_config.sh"
+
+function usage() {
+    echo -n "Usage: $(basename "$0") {git,app} [VERSIONS]
+Run tests.
+
+Options:
+    -h --help       Display this help text
+    git             Check git commit titles
+    app             Run tests for the app, optionally limited to Python/Django VERSIONS
+    <none>          Run all tests
+
+Versions:
+    When running tests for the app, you can limit the Python/Django versions you'd like
+    to test in order to speed up test execution. For example, the following command will only
+    run tests for Python 3.4 and Django 1.11:
+
+        ./scripts/test app py34-django111
+
+    To view available versions, see the envlist in the tox.ini file at the root of
+    this repo.
+"
+}
+
+function app_tests() {
+    echo "Testing the app..."
+    echo "-------------------------------------------------------------------"
+
+    docker run ashlar-schema-editor test
+
+    echo "PASSED: app tests passed."
+
+}
+
+function git_tests() {
+    # Fail build if any commit title in this branch contains these words
+    echo "Making sure that all commits in this branch are clean..."
+    echo "-------------------------------------------------------------------"
+    if git log --oneline master.. | grep -wiE "fixup|squash|wip"
+    then
+        echo "FAILED: Illegal words in git commit:"
+        echo
+        echo $(git log --oneline master.. | grep -wiE "fixup|squash|wip")
+        echo
+        echo "Please squash these changes before merging."
+        exit 1
+    else
+        echo "PASSED: Git commits are clean."
+    fi
+}
+
+function all_tests() {
+    echo "Running all tests..."
+    echo "-------------------------------------------------------------------"
+    app_tests
+    echo "-------------------------------------------------------------------"
+    git_tests
+    echo "-------------------------------------------------------------------"
+    echo "PASSED: All tests passed."
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ -z "$1" ]
+    then
+        # If no arguments are supplied, run app tests.
+        all_tests
+    else
+        case "${1:-}" in
+            -h|--help) usage ;;
+            git)       git_tests ;;
+            app)       shift 1 && app_tests "$@" ;;
+            *)         usage ;;
+        esac
+    fi
+fi

--- a/scripts/update
+++ b/scripts/update
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Most reliable way to get the path for this script.
+# h/t: https://stackoverflow.com/questions/192292/bash-how-best-to-include-other-scripts/12694189#12694189
+DIR="${BASH_SOURCE%/*}"
+if [[ ! -d "$DIR" ]];
+then
+    DIR="$PWD"
+fi
+
+# Load common configs for this script.
+source "${DIR}/_config.sh"
+
+function usage() {
+    echo -n "Usage: $(basename "$0")
+
+Make sure containers are up to date.
+"
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]
+then
+    if [ "${1:-}" = "--help" ]
+    then
+        usage
+    else
+        docker build -t ashlar-schema-editor:latest .
+    fi
+fi

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -1,0 +1,32 @@
+{
+  "node": true,
+  "browser": true,
+  "esnext": true,
+  "bitwise": true,
+  "camelcase": true,
+  "curly": true,
+  "eqeqeq": true,
+  "immed": true,
+  "indent": 2,
+  "latedef": true,
+  "newcap": true,
+  "noarg": true,
+  "quotmark": "single",
+  "regexp": true,
+  "undef": true,
+  "unused": true,
+  "strict": true,
+  "trailing": true,
+  "smarttabs": true,
+  "jasmine": true,
+  "globals": {
+    "_": true,
+    "angular": false,
+    "browser": false,
+    "inject": false,
+    "L": false,
+    "jsonSchemaV4": true,
+    "jjv": true,
+    "readJSON": true
+  }
+}

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -1,0 +1,310 @@
+// Karma configuration
+// http://karma-runner.github.io/0.12/config/configuration-file.html
+// Generated on 2015-05-01 using
+// generator-karma 1.0.0
+
+module.exports = function(config) {
+  'use strict';
+
+  config.set({
+    // enable / disable watching file and executing tests whenever any file changes
+    autoWatch: true,
+
+    // base path, that will be used to resolve files and exclude
+    basePath: '../',
+
+    // testing framework to use (jasmine/mocha/qunit/...)
+    // as well as any additional frameworks (requirejs/chai/sinon/...)
+    frameworks: [
+      'jasmine'
+    ],
+
+    preprocessors: {
+      'app/scripts/**/*.html': ['ng-html2js']
+    },
+
+    // list of files / patterns to load in the browser
+    files: [
+      // bower:js
+      'bower_components/jquery/dist/jquery.js',
+      'bower_components/angular/angular.js',
+      'bower_components/moment/moment.js',
+      'bower_components/eonasdan-bootstrap-datetimepicker/build/js/bootstrap-datetimepicker.min.js',
+      'bower_components/angular-bootstrap-datetimepicker-directive/angular-bootstrap-datetimepicker-directive.js',
+      'bower_components/bootstrap-sass-official/assets/javascripts/bootstrap.js',
+      'bower_components/angular-animate/angular-animate.js',
+      'bower_components/angular-aria/angular-aria.js',
+      'bower_components/angular-cookies/angular-cookies.js',
+      'bower_components/ng-file-upload/ng-file-upload.js',
+      'bower_components/angular-spinkit/build/angular-spinkit.js',
+      'bower_components/angular-resource/angular-resource.js',
+      'bower_components/angular-sanitize/angular-sanitize.js',
+      'bower_components/angular-ui-router/release/angular-ui-router.js',
+      'bower_components/angular-uuids/angular-uuid.js',
+      'bower_components/json-editor/dist/jsoneditor.js',
+      'bower_components/angular-local-storage/dist/angular-local-storage.js',
+      'bower_components/angular-bootstrap/ui-bootstrap-tpls.js',
+      'bower_components/lodash/lodash.js',
+      'bower_components/moment-timezone/builds/moment-timezone-with-data-2010-2020.js',
+      'bower_components/leaflet/dist/leaflet-src.js',
+      'bower_components/world-calendars/jquery.plugin.js',
+      'bower_components/world-calendars/jquery.calendars.js',
+      'bower_components/world-calendars/jquery.calendars.plus.js',
+      'bower_components/world-calendars/jquery.calendars.picker.js',
+      'bower_components/world-calendars/jquery.calendars.picker.ext.js',
+      'bower_components/world-calendars/jquery.calendars.picker.lang.js',
+      'bower_components/world-calendars/jquery.calendars-af.js',
+      'bower_components/world-calendars/jquery.calendars-am.js',
+      'bower_components/world-calendars/jquery.calendars-ar-DZ.js',
+      'bower_components/world-calendars/jquery.calendars-ar-EG.js',
+      'bower_components/world-calendars/jquery.calendars-ar.js',
+      'bower_components/world-calendars/jquery.calendars-az.js',
+      'bower_components/world-calendars/jquery.calendars-bg.js',
+      'bower_components/world-calendars/jquery.calendars-bn.js',
+      'bower_components/world-calendars/jquery.calendars-bs.js',
+      'bower_components/world-calendars/jquery.calendars-ca.js',
+      'bower_components/world-calendars/jquery.calendars-cs.js',
+      'bower_components/world-calendars/jquery.calendars-da.js',
+      'bower_components/world-calendars/jquery.calendars-de-CH.js',
+      'bower_components/world-calendars/jquery.calendars-de.js',
+      'bower_components/world-calendars/jquery.calendars-el.js',
+      'bower_components/world-calendars/jquery.calendars-en-AU.js',
+      'bower_components/world-calendars/jquery.calendars-en-GB.js',
+      'bower_components/world-calendars/jquery.calendars-en-NZ.js',
+      'bower_components/world-calendars/jquery.calendars-eo.js',
+      'bower_components/world-calendars/jquery.calendars-es-AR.js',
+      'bower_components/world-calendars/jquery.calendars-es.js',
+      'bower_components/world-calendars/jquery.calendars-es-PE.js',
+      'bower_components/world-calendars/jquery.calendars-et.js',
+      'bower_components/world-calendars/jquery.calendars-eu.js',
+      'bower_components/world-calendars/jquery.calendars-fa.js',
+      'bower_components/world-calendars/jquery.calendars-fi.js',
+      'bower_components/world-calendars/jquery.calendars-fo.js',
+      'bower_components/world-calendars/jquery.calendars-fr-CH.js',
+      'bower_components/world-calendars/jquery.calendars-fr.js',
+      'bower_components/world-calendars/jquery.calendars-gl.js',
+      'bower_components/world-calendars/jquery.calendars-gu.js',
+      'bower_components/world-calendars/jquery.calendars-he.js',
+      'bower_components/world-calendars/jquery.calendars-hi-IN.js',
+      'bower_components/world-calendars/jquery.calendars-hr.js',
+      'bower_components/world-calendars/jquery.calendars-hu.js',
+      'bower_components/world-calendars/jquery.calendars-hy.js',
+      'bower_components/world-calendars/jquery.calendars-id.js',
+      'bower_components/world-calendars/jquery.calendars-is.js',
+      'bower_components/world-calendars/jquery.calendars-it.js',
+      'bower_components/world-calendars/jquery.calendars-ja.js',
+      'bower_components/world-calendars/jquery.calendars-ka.js',
+      'bower_components/world-calendars/jquery.calendars-km.js',
+      'bower_components/world-calendars/jquery.calendars-ko.js',
+      'bower_components/world-calendars/jquery.calendars-lo.js',
+      'bower_components/world-calendars/jquery.calendars-lt.js',
+      'bower_components/world-calendars/jquery.calendars-lv.js',
+      'bower_components/world-calendars/jquery.calendars-me.js',
+      'bower_components/world-calendars/jquery.calendars-me-ME.js',
+      'bower_components/world-calendars/jquery.calendars-mk.js',
+      'bower_components/world-calendars/jquery.calendars-ml.js',
+      'bower_components/world-calendars/jquery.calendars-ms.js',
+      'bower_components/world-calendars/jquery.calendars-mt.js',
+      'bower_components/world-calendars/jquery.calendars-nl-BE.js',
+      'bower_components/world-calendars/jquery.calendars-nl.js',
+      'bower_components/world-calendars/jquery.calendars-no.js',
+      'bower_components/world-calendars/jquery.calendars-pa.js',
+      'bower_components/world-calendars/jquery.calendars-pl.js',
+      'bower_components/world-calendars/jquery.calendars-pt-BR.js',
+      'bower_components/world-calendars/jquery.calendars-rm.js',
+      'bower_components/world-calendars/jquery.calendars-ro.js',
+      'bower_components/world-calendars/jquery.calendars-ru.js',
+      'bower_components/world-calendars/jquery.calendars-sk.js',
+      'bower_components/world-calendars/jquery.calendars-sl.js',
+      'bower_components/world-calendars/jquery.calendars-sq.js',
+      'bower_components/world-calendars/jquery.calendars-sr.js',
+      'bower_components/world-calendars/jquery.calendars-sr-SR.js',
+      'bower_components/world-calendars/jquery.calendars-sv.js',
+      'bower_components/world-calendars/jquery.calendars-ta.js',
+      'bower_components/world-calendars/jquery.calendars-th.js',
+      'bower_components/world-calendars/jquery.calendars-tr.js',
+      'bower_components/world-calendars/jquery.calendars-tt.js',
+      'bower_components/world-calendars/jquery.calendars-uk.js',
+      'bower_components/world-calendars/jquery.calendars-ur.js',
+      'bower_components/world-calendars/jquery.calendars-vi.js',
+      'bower_components/world-calendars/jquery.calendars-zh-CN.js',
+      'bower_components/world-calendars/jquery.calendars-zh-HK.js',
+      'bower_components/world-calendars/jquery.calendars-zh-TW.js',
+      'bower_components/world-calendars/jquery.calendars.picker-af.js',
+      'bower_components/world-calendars/jquery.calendars.picker-am.js',
+      'bower_components/world-calendars/jquery.calendars.picker-ar-DZ.js',
+      'bower_components/world-calendars/jquery.calendars.picker-ar-EG.js',
+      'bower_components/world-calendars/jquery.calendars.picker-ar.js',
+      'bower_components/world-calendars/jquery.calendars.picker-az.js',
+      'bower_components/world-calendars/jquery.calendars.picker-bg.js',
+      'bower_components/world-calendars/jquery.calendars.picker-bn.js',
+      'bower_components/world-calendars/jquery.calendars.picker-bs.js',
+      'bower_components/world-calendars/jquery.calendars.picker-ca.js',
+      'bower_components/world-calendars/jquery.calendars.picker-cs.js',
+      'bower_components/world-calendars/jquery.calendars.picker-da.js',
+      'bower_components/world-calendars/jquery.calendars.picker-de-CH.js',
+      'bower_components/world-calendars/jquery.calendars.picker-de.js',
+      'bower_components/world-calendars/jquery.calendars.picker-el.js',
+      'bower_components/world-calendars/jquery.calendars.picker-en-AU.js',
+      'bower_components/world-calendars/jquery.calendars.picker-en-GB.js',
+      'bower_components/world-calendars/jquery.calendars.picker-en-NZ.js',
+      'bower_components/world-calendars/jquery.calendars.picker-eo.js',
+      'bower_components/world-calendars/jquery.calendars.picker-es-AR.js',
+      'bower_components/world-calendars/jquery.calendars.picker-es.js',
+      'bower_components/world-calendars/jquery.calendars.picker-es-PE.js',
+      'bower_components/world-calendars/jquery.calendars.picker-et.js',
+      'bower_components/world-calendars/jquery.calendars.picker-eu.js',
+      'bower_components/world-calendars/jquery.calendars.picker-fa.js',
+      'bower_components/world-calendars/jquery.calendars.picker-fi.js',
+      'bower_components/world-calendars/jquery.calendars.picker-fo.js',
+      'bower_components/world-calendars/jquery.calendars.picker-fr-CH.js',
+      'bower_components/world-calendars/jquery.calendars.picker-fr.js',
+      'bower_components/world-calendars/jquery.calendars.picker-gl.js',
+      'bower_components/world-calendars/jquery.calendars.picker-gu.js',
+      'bower_components/world-calendars/jquery.calendars.picker-he.js',
+      'bower_components/world-calendars/jquery.calendars.picker-hi-IN.js',
+      'bower_components/world-calendars/jquery.calendars.picker-hr.js',
+      'bower_components/world-calendars/jquery.calendars.picker-hu.js',
+      'bower_components/world-calendars/jquery.calendars.picker-hy.js',
+      'bower_components/world-calendars/jquery.calendars.picker-id.js',
+      'bower_components/world-calendars/jquery.calendars.picker-is.js',
+      'bower_components/world-calendars/jquery.calendars.picker-it.js',
+      'bower_components/world-calendars/jquery.calendars.picker-ja.js',
+      'bower_components/world-calendars/jquery.calendars.picker-ka.js',
+      'bower_components/world-calendars/jquery.calendars.picker-km.js',
+      'bower_components/world-calendars/jquery.calendars.picker-ko.js',
+      'bower_components/world-calendars/jquery.calendars.picker-lo.js',
+      'bower_components/world-calendars/jquery.calendars.picker-lt.js',
+      'bower_components/world-calendars/jquery.calendars.picker-lv.js',
+      'bower_components/world-calendars/jquery.calendars.picker-me.js',
+      'bower_components/world-calendars/jquery.calendars.picker-me-ME.js',
+      'bower_components/world-calendars/jquery.calendars.picker-mk.js',
+      'bower_components/world-calendars/jquery.calendars.picker-ml.js',
+      'bower_components/world-calendars/jquery.calendars.picker-ms.js',
+      'bower_components/world-calendars/jquery.calendars.picker-mt.js',
+      'bower_components/world-calendars/jquery.calendars.picker-nl-BE.js',
+      'bower_components/world-calendars/jquery.calendars.picker-nl.js',
+      'bower_components/world-calendars/jquery.calendars.picker-no.js',
+      'bower_components/world-calendars/jquery.calendars.picker-pl.js',
+      'bower_components/world-calendars/jquery.calendars.picker-pt-BR.js',
+      'bower_components/world-calendars/jquery.calendars.picker-rm.js',
+      'bower_components/world-calendars/jquery.calendars.picker-ro.js',
+      'bower_components/world-calendars/jquery.calendars.picker-ru.js',
+      'bower_components/world-calendars/jquery.calendars.picker-sk.js',
+      'bower_components/world-calendars/jquery.calendars.picker-sl.js',
+      'bower_components/world-calendars/jquery.calendars.picker-sq.js',
+      'bower_components/world-calendars/jquery.calendars.picker-sr.js',
+      'bower_components/world-calendars/jquery.calendars.picker-sr-SR.js',
+      'bower_components/world-calendars/jquery.calendars.picker-sv.js',
+      'bower_components/world-calendars/jquery.calendars.picker-ta.js',
+      'bower_components/world-calendars/jquery.calendars.picker-th.js',
+      'bower_components/world-calendars/jquery.calendars.picker-tr.js',
+      'bower_components/world-calendars/jquery.calendars.picker-tt.js',
+      'bower_components/world-calendars/jquery.calendars.picker-uk.js',
+      'bower_components/world-calendars/jquery.calendars.picker-ur.js',
+      'bower_components/world-calendars/jquery.calendars.picker-vi.js',
+      'bower_components/world-calendars/jquery.calendars.picker-zh-CN.js',
+      'bower_components/world-calendars/jquery.calendars.picker-zh-HK.js',
+      'bower_components/world-calendars/jquery.calendars.picker-zh-TW.js',
+      'bower_components/world-calendars/jquery.calendars.islamic.js',
+      'bower_components/world-calendars/jquery.calendars.ummalqura.js',
+      'bower_components/world-calendars/jquery.calendars.islamic-ar.js',
+      'bower_components/world-calendars/jquery.calendars.ummalqura-ar.js',
+      'bower_components/angular-mocks/angular-mocks.js',
+      'bower_components/jjv/lib/jjv.js',
+      'bower_components/karma-read-json/karma-read-json.js',
+      // endbower
+      'app/scripts/config.js',
+      'app/scripts/**/*.html',
+      'app/scripts/utils/module.js',
+      'app/scripts/utils/**.js',
+      'app/scripts/directives/module.js',
+      'app/scripts/directives/**.js',
+      'app/scripts/userdata/module.js',
+      'app/scripts/userdata/**.js',
+      'app/scripts/auth/module.js',
+      'app/scripts/auth/**.js',
+      'app/scripts/schemas/module.js',
+      'app/scripts/schemas/**.js',
+      'app/scripts/resources/module.js',
+      'app/scripts/resources/**.js',
+      'app/scripts/json-editor/module.js',
+      'app/scripts/json-editor/**.js',
+      'app/scripts/notifications/module.js',
+      'app/scripts/notifications/**.js',
+      'app/scripts/navbar/module.js',
+      'app/scripts/navbar/**.js',
+      'app/scripts/views/sidebar/module.js',
+      'app/scripts/views/sidebar/**.js',
+      'app/scripts/views/geography/module.js',
+      'app/scripts/views/geography/**.js',
+      'app/scripts/views/login/module.js',
+      'app/scripts/views/login/**.js',
+      'app/scripts/views/recordtype/module.js',
+      'app/scripts/views/recordtype/**.js',
+      'app/scripts/views/settings/module.js',
+      'app/scripts/views/settings/**.js',
+      'app/scripts/views/usermgmt/module.js',
+      'app/scripts/views/usermgmt/**.js',
+      'test/mock/**/*.js',
+      'test/spec/**/*.js',
+      'app/scripts/app.js',
+
+      // builder-schemas json files
+      {
+          pattern: 'app/builder-schemas/*.json',
+          included: false
+      }
+    ],
+
+    // list of files / patterns to exclude
+    exclude: [
+    ],
+
+    // web server port
+    port: 8080,
+
+    // Start these browsers, currently available:
+    // - Chrome
+    // - ChromeCanary
+    // - Firefox
+    // - Opera
+    // - Safari (only Mac)
+    // - PhantomJS
+    // - IE (only Windows)
+    browsers: [
+      'PhantomJS'
+    ],
+
+    // Which plugins to enable
+    plugins: [
+      'karma-phantomjs-launcher',
+      'karma-jasmine',
+      'karma-ng-html2js-preprocessor'
+    ],
+
+    // Load all templates into $templateCache. They can be imported with:
+    //   beforeEach(module('ase.templates'));
+    ngHtml2JsPreprocessor: {
+      stripPrefix: 'app/',
+      moduleName: 'ase.templates'
+    },
+
+    // Continuous Integration mode
+    // if true, it capture browsers, run tests and exit
+    singleRun: false,
+
+    colors: true,
+
+    // level of logging
+    // possible values: LOG_DISABLE || LOG_ERROR || LOG_WARN || LOG_INFO || LOG_DEBUG
+    logLevel: config.LOG_INFO,
+
+    // Uncomment the following lines if you are using grunt's server to run the tests
+    // proxies: {
+    //   '/': 'http://localhost:9000/'
+    // },
+    // URL root prevent conflicts with the site root
+    // urlRoot: '_karma_'
+  });
+};

--- a/test/mock/config.js
+++ b/test/mock/config.js
@@ -1,0 +1,28 @@
+(function () {
+    'use strict';
+
+    var config = {
+        debug: true,
+        html5Mode: {
+            enabled: false,
+            prefix: '!'
+        },
+        api: {
+            hostname: 'http://localhost:7000',
+            groups: {
+                admin: 'admin',
+                readOnly: 'public',
+                readWrite: 'analyst'
+            }
+        },
+        record: {
+            limit: 50
+        },
+        localization: {
+            timeZone: 'America/New_York'
+        }
+    };
+
+    angular.module('ase.config', [])
+    .constant('ASEConfig', config);
+})();

--- a/test/mock/json-schema-v4.js
+++ b/test/mock/json-schema-v4.js
@@ -1,0 +1,158 @@
+'use strict';
+
+/**
+ * Return the json schema v4, copied from
+ * http://json-schema.org/draft-04/schema#
+ */
+function jsonSchemaV4() {
+    return {
+        'id': 'http://json-schema.org/draft-04/schema#',
+        '$schema': 'http://json-schema.org/draft-04/schema#',
+        'description': 'Core schema meta-schema',
+        'definitions': {
+            'schemaArray': {
+                'type': 'array',
+                'minItems': 1,
+                'items': { '$ref': '#' }
+            },
+            'positiveInteger': {
+                'type': 'integer',
+                'minimum': 0
+            },
+            'positiveIntegerDefault0': {
+                'allOf': [ { '$ref': '#/definitions/positiveInteger' }, { 'default': 0 } ]
+            },
+            'simpleTypes': {
+                'enum': [ 'array', 'boolean', 'integer', 'null', 'number', 'object', 'string' ]
+            },
+            'stringArray': {
+                'type': 'array',
+                'items': { 'type': 'string' },
+                'minItems': 1,
+                'uniqueItems': true
+            }
+        },
+        'type': 'object',
+        'properties': {
+            'id': {
+                'type': 'string',
+                'format': 'uri'
+            },
+            '$schema': {
+                'type': 'string',
+                'format': 'uri'
+            },
+            'title': {
+                'type': 'string'
+            },
+            'description': {
+                'type': 'string'
+            },
+            'default': {},
+            'multipleOf': {
+                'type': 'number',
+                'minimum': 0,
+                'exclusiveMinimum': true
+            },
+            'maximum': {
+                'type': 'number'
+            },
+            'exclusiveMaximum': {
+                'type': 'boolean',
+                'default': false
+            },
+            'minimum': {
+                'type': 'number'
+            },
+            'exclusiveMinimum': {
+                'type': 'boolean',
+                'default': false
+            },
+            'maxLength': { '$ref': '#/definitions/positiveInteger' },
+            'minLength': { '$ref': '#/definitions/positiveIntegerDefault0' },
+            'pattern': {
+                'type': 'string',
+                'format': 'regex'
+            },
+            'additionalItems': {
+                'anyOf': [
+                { 'type': 'boolean' },
+                { '$ref': '#' }
+                ],
+                'default': {}
+            },
+            'items': {
+                'anyOf': [
+                { '$ref': '#' },
+                { '$ref': '#/definitions/schemaArray' }
+                ],
+                'default': {}
+            },
+            'maxItems': { '$ref': '#/definitions/positiveInteger' },
+            'minItems': { '$ref': '#/definitions/positiveIntegerDefault0' },
+            'uniqueItems': {
+                'type': 'boolean',
+                'default': false
+            },
+            'maxProperties': { '$ref': '#/definitions/positiveInteger' },
+            'minProperties': { '$ref': '#/definitions/positiveIntegerDefault0' },
+            'required': { '$ref': '#/definitions/stringArray' },
+            'additionalProperties': {
+                'anyOf': [
+                { 'type': 'boolean' },
+                { '$ref': '#' }
+                ],
+                'default': {}
+            },
+            'definitions': {
+                'type': 'object',
+                'additionalProperties': { '$ref': '#' },
+                'default': {}
+            },
+            'properties': {
+                'type': 'object',
+                'additionalProperties': { '$ref': '#' },
+                'default': {}
+            },
+            'patternProperties': {
+                'type': 'object',
+                'additionalProperties': { '$ref': '#' },
+                'default': {}
+            },
+            'dependencies': {
+                'type': 'object',
+                'additionalProperties': {
+                    'anyOf': [
+                    { '$ref': '#' },
+                    { '$ref': '#/definitions/stringArray' }
+                    ]
+                }
+            },
+            'enum': {
+                'type': 'array',
+                'minItems': 1,
+                'uniqueItems': true
+            },
+            'type': {
+                'anyOf': [
+                { '$ref': '#/definitions/simpleTypes' },
+                {
+                    'type': 'array',
+                    'items': { '$ref': '#/definitions/simpleTypes' },
+                    'minItems': 1,
+                    'uniqueItems': true
+                }
+                ]
+            },
+            'allOf': { '$ref': '#/definitions/schemaArray' },
+            'anyOf': { '$ref': '#/definitions/schemaArray' },
+            'oneOf': { '$ref': '#/definitions/schemaArray' },
+            'not': { '$ref': '#' }
+        },
+        'dependencies': {
+            'exclusiveMaximum': [ 'maximum' ],
+            'exclusiveMinimum': [ 'minimum' ]
+        },
+        'default': {}
+    };
+}

--- a/test/mock/resources/driver-resources-mocks.js
+++ b/test/mock/resources/driver-resources-mocks.js
@@ -1,0 +1,428 @@
+(function () {
+    'use strict';
+
+    function DriverResourcesMock () {
+
+        var RecordList = [
+            {
+                'uuid': '35d74ce1-7b08-486b-b791-da9bc1e93cfb',
+                'archived': false,
+                'data': {
+                    'Person': [],
+                    'Crime Details': {
+                        'County': 'Philadelphia',
+                        'Description': 'First test',
+                        'District': '13',
+                        '_localId': 'e116f30b-e493-4d57-9797-a901abddf7d5'
+                    },
+                    'Vehicle': []
+                },
+                'created': '2015-07-30T17:36:29.483160Z',
+                'modified': '2015-07-30T17:36:29.483206Z',
+                'occurred_from': '2015-07-30T17:36:29.263000Z',
+                'occurred_to': '2015-07-30T17:36:29.263000Z',
+                'geom': {
+                    'type': 'Point',
+                    'coordinates': [
+                        25.0,
+                        75.0
+                    ]
+                },
+                'location_text': '',
+                'schema': 'db446730-3d6d-40b3-8699-0027205d54ed'
+            },
+            {
+                'uuid': '57dd6700-6e87-4110-ab11-dc7eefc50c96',
+                'archived': false,
+                'data': {
+                    'Person': [
+                        {
+                            'Last name': 'John',
+                            'First name': 'Smith',
+                            'Street address': '3 Test St.',
+                            '_localId': '4cde1cc9-2cd2-487b-983d-ae1de1d6198c'
+                        },
+                        {
+                            'Last name': 'Jane',
+                            'First name': 'Doe',
+                            'Street address': '4 Test Ln.',
+                            '_localId': 'b383cf8c-95f2-46de-aaed-d05115db8d4d'
+                        }
+                    ],
+                    'Crime Details': {
+                        'County': 'Philadelphia',
+                        'Description': 'Second test',
+                        'District': '14',
+                        '_localId': '2382abab-0958-4aef-a1f6-ccca379ae9a4'
+                    },
+                    'location_text': '',
+                    'schema': 'db446730-3d6d-40b3-8699-0027205d54ed'
+                }
+            },
+            {
+                "uuid": "80621b6f-4036-45c5-940b-796f23ea0185",
+                "data": {
+                    "interventionDetails": {
+                        "Type": "Intersection - Roundabout",
+                        "_localId": "dddb643b-18ae-4b3d-8eba-e3d59c7fb14f"
+                    }
+                },
+                "created": "2016-02-02T19:11:00.479893Z",
+                "modified": "2016-02-02T19:11:00.479924Z",
+                "occurred_from": "2016-02-02T06:11:00.395264Z",
+                "occurred_to": "2016-02-02T06:11:00.395273Z",
+                "geom": {
+                    "type": "Point",
+                    "coordinates": [
+                        121.03756381620197,
+                        14.644203676970669
+                    ]
+                },
+                "location_text": null,
+                "city": null,
+                "city_district": null,
+                "county": null,
+                "neighborhood": null,
+                "road": null,
+                "state": null,
+                "weather": null,
+                "light": null,
+                "schema": "d71e6475-e328-41d3-8e1f-556ab4145129"
+            }
+        ];
+
+        var RecordResponse = {
+            'count': 3,
+            'next': null,
+            'previous': null,
+            'results': RecordList
+        };
+
+        var BoundaryResponse = {
+            "count": 1,
+            "next": null,
+            "previous": null,
+            "results": [
+                {
+                    "uuid": "ce9b10ef-1cec-46e9-8a0b-4c7d9c0881ab",
+                    "label": "admin zero",
+                    "color": "#fffff",
+                    "display_field": "",
+                    "data_fields": [
+                        "GADMID",
+                        "ISO",
+                        "NAME_ENGLI",
+                        "NAME_ISO",
+                        "NAME_FAO",
+                        "NAME_LOCAL",
+                        "NAME_OBSOL",
+                        "NAME_VARIA",
+                        "NAME_NONLA",
+                        "NAME_FRENC",
+                        "NAME_SPANI",
+                        "NAME_RUSSI",
+                        "NAME_ARABI",
+                        "NAME_CHINE",
+                        "WASPARTOF",
+                        "CONTAINS",
+                        "SOVEREIGN",
+                        "ISO2",
+                        "WWW",
+                        "FIPS",
+                        "ISON",
+                        "VALIDFR",
+                        "VALIDTO",
+                        "AndyID",
+                        "POP2000",
+                        "SQKM",
+                        "POPSQKM",
+                        "UNREGION1",
+                        "UNREGION2",
+                        "DEVELOPING",
+                        "CIS",
+                        "Transition",
+                        "OECD",
+                        "WBREGION",
+                        "WBINCOME",
+                        "WBDEBT",
+                        "WBOTHER",
+                        "CEEAC",
+                        "CEMAC",
+                        "CEPLG",
+                        "COMESA",
+                        "EAC",
+                        "ECOWAS",
+                        "IGAD",
+                        "IOC",
+                        "MRU",
+                        "SACU",
+                        "UEMOA",
+                        "UMA",
+                        "PALOP",
+                        "PARTA",
+                        "CACM",
+                        "EurAsEC",
+                        "Agadir",
+                        "SAARC",
+                        "ASEAN",
+                        "NAFTA",
+                        "GCC",
+                        "CSN",
+                        "CARICOM",
+                        "EU",
+                        "CAN",
+                        "ACP",
+                        "Landlocked",
+                        "AOSIS",
+                        "SIDS",
+                        "Islands",
+                        "LDC",
+                        "Shape_Leng",
+                        "Shape_Area"
+                    ],
+                    "errors": null,
+                    "created": "2015-09-11T15:07:54.893439Z",
+                    "modified": "2015-09-11T15:07:56.876548Z",
+                    "status": "COMPLETE",
+                    "source_file": "http://localhost:7000/media/boundaries/2015/09/11/PHL_adm0.zip"
+                }
+            ]
+        };
+
+        var PolygonResponse = {
+            'count': 3,
+            'next': null,
+            'previous': null,
+            'results': {
+                'type': 'FeatureCollection',
+                'features': [
+                    {
+                        'id': '8275cda9-ba6a-493b-9fb1-409dd8659a43',
+                        'type': 'Feature',
+                        'geometry': {
+                            'type': 'MultiPolygon',
+                            'coordinates': [[[
+                                [-75.18023798707824, 39.98634201985354],
+                                [-75.17990304282124, 39.986089975971524],
+                                [-75.17970297881145, 39.98593905049045],
+                                [-75.17957996535179, 39.98584695753356],
+                                [-75.18023798707824, 39.98634201985354]
+                            ]]]
+                        },
+                        'properties': {
+                            'data': {
+                                'name': 'Polygon #1'
+                            },
+                            'created': '2015-08-10T12:21:23.912703Z',
+                            'modified': '2015-08-10T12:21:23.912941Z'
+                        }
+                    },
+                    {
+                        'id':'7d6445ee-fcdb-4a6a-ba5c-3867bc3494d0',
+                        'type': 'Feature',
+                        'geometry': {
+                            'type': 'MultiPolygon',
+                            'coordinates': [[[
+                                [-75.28023798707824, 39.98634201985354],
+                                [-75.27990304282124, 39.986089975971524],
+                                [-75.27970297881145, 39.98593905049045],
+                                [-75.27957996535179, 39.98584695753356],
+                                [-75.28023798707824, 39.98634201985354]
+                            ]]]
+                        },
+                        'properties': {
+                            'data': {
+                                'name': 'Polygon #2'
+                            },
+                            'created': '2015-08-20T12:21:23.912703Z',
+                            'modified': '2015-08-20T12:21:23.912941Z'
+                        }
+                    },
+                    {
+                        'id':'351da4bf-f705-4178-a156-3b7593a2adde',
+                        'type': 'Feature',
+                        'geometry': {
+                            'type': 'MultiPolygon',
+                            'coordinates': [[[
+                                [-75.38023798707824, 39.98634201985354],
+                                [-75.37990304282124, 39.986089975971524],
+                                [-75.37970297881145, 39.98593905049045],
+                                [-75.37957996535179, 39.98584695753356],
+                                [-75.38023798707824, 39.98634201985354]
+                            ]]]
+                        },
+                        'properties': {
+                            'data': {
+                                'name': 'Polygon #3'
+                            },
+                            'created': '2015-08-30T12:21:23.912703Z',
+                            'modified': '2015-08-30T12:21:23.912941Z'
+                        }
+                    }
+                ]
+            }
+        };
+
+        var SavedFiltersResponse = {
+            'count': 5,
+            'next': null,
+            'previous': null,
+            'results': [
+                {
+                    'uuid': '89ef93ac-e011-4ca1-bec7-4dbbb8cb63a9',
+                    'filter_json': {
+                        'Incident Details#Severity': {
+                            'contains': [
+                                'Injury'
+                            ],
+                            '_rule_type': 'containment'
+                        }
+                    },
+                    'label': 'Injury filter',
+                    'owner': 1
+                },
+                {
+                    'uuid': '4a270f45-eaf6-4c04-aeb7-1ee78998a38e',
+                    'filter_json': {
+                        'Incident Details#Severity': {
+                            'contains': [
+                                'Injury'
+                            ],
+                            '_rule_type': 'containment'
+                        },
+                        'Incident Details#Num driver casualties': {
+                            '_rule_type': 'intrange',
+                            'min': 2
+                        }
+                    },
+                    'label': 'Injury with min casualties filter',
+                    'owner': 1
+                },
+                {
+                    'uuid': 'ec6b4c9a-4527-4abc-b943-3ab576da0070',
+                    'filter_json': {
+                        'Incident Details#Severity': {
+                            'contains': [
+                                'Injury'
+                            ],
+                            '_rule_type': 'containment'
+                        },
+                        'Incident Details#Num driver casualties': {
+                            'max': 4,
+                            '_rule_type': 'intrange',
+                            'min': null
+                        }
+                    },
+                    'label': 'Injury with max casualties filter',
+                    'owner': 1
+                },
+                {
+                    'uuid': 'f5779d32-a3e4-49a1-9e84-cb76c157589e',
+                    'filter_json': {
+                        'Incident Details#Severity': {
+                            'contains': [
+                                'Injury'
+                            ],
+                            '_rule_type': 'containment'
+                        },
+                        'Incident Details#Num driver casualties': {
+                            'max': 4,
+                            '_rule_type': 'intrange',
+                            'min': 1
+                        }
+                    },
+                    'label': 'Injury with casualty range',
+                    'owner': 1
+                },
+                {
+                    'uuid': '0a1235a1-fd2b-49d2-986d-81d677d546f1',
+                    'filter_json': {
+                        'Incident Details#Main cause': {
+                            'contains': [
+                                'Vehicle defect'
+                            ],
+                            '_rule_type': 'containment'
+                        },
+                        'Incident Details#Weather': {
+                            'contains': [
+                                'Wind'
+                            ],
+                            '_rule_type': 'containment'
+                        },
+                        'Incident Details#Num driver casualties': {
+                            'max': 4,
+                            '_rule_type': 'intrange',
+                            'min': 1
+                        },
+                        'Incident Details#Severity': {
+                            'contains': [
+                                'Injury'
+                            ],
+                            '_rule_type': 'containment'
+                        },
+                        'Incident Details#Collision type': {
+                            'contains': [
+                                'Right angle'
+                            ],
+                            '_rule_type': 'containment'
+                        }
+                    },
+                    'label': 'Very specific filter',
+                    'owner': 1
+                }
+            ]
+        };
+
+        var SSOClientsResponse = {
+            'clients': ['google.com']
+        };
+
+        var BlackspotSetResponse = {
+            results: [{
+                uuid: 'uuid'
+            }]
+        };
+
+        var BlackspotResponse = {
+            results: [{
+                uuid: 'uuid',
+                severity_score: 'severity_score',
+                num_records: 'num_records',
+                num_severe: 'num_severe'
+            }]
+        };
+
+        var DuplicatesResponse = {
+            'count': 1,
+            'next': null,
+            'previous': null,
+            'results': [
+                {
+                    uuid: '0cf5604a-a743-4c30-9fc2-a8820d543fd8',
+                    created: '2016-02-03T19:20:31.266354Z',
+                    modified: '2016-02-08T14:51:51.169961Z',
+                    score: 0.0,
+                    resolved: false,
+                    job: '05b59583-2776-458c-835d-b7747a82b7d9',
+                    record: RecordList[0],
+                    duplicate_record: RecordList[1]
+                }
+            ]
+        };
+
+        return {
+            BoundaryResponse: BoundaryResponse,
+            PolygonResponse: PolygonResponse,
+            RecordResponse: RecordResponse,
+            SavedFiltersResponse: SavedFiltersResponse,
+            SSOClientsResponse: SSOClientsResponse,
+            BlackspotSetResponse: BlackspotSetResponse,
+            BlackspotResponse: BlackspotResponse,
+            DuplicatesResponse: DuplicatesResponse
+        };
+    }
+
+    angular.module('driver.mock.resources', [])
+    .factory('DriverResourcesMock', DriverResourcesMock);
+
+})();

--- a/test/mock/resources/resources-mocks.js
+++ b/test/mock/resources/resources-mocks.js
@@ -1,0 +1,344 @@
+
+(function () {
+    'use strict';
+
+    function ResourcesMock () {
+        var GeographyResponse = {
+            'count': 1,
+            'next': null,
+            'previous': null,
+            'results': [{
+                'uuid': '80c10057-2cfc-4a32-8e3c-0573e8bf853f',
+                'label': 'some_geo',
+                'color': 'fuschia',
+                'display_field': 'ballparks',
+                'data_fields': ['ballparks'],
+                'errors': null,
+                'created': '2015-05-13T00:22:50.465802Z',
+                'modified': '2015-05-13T00:23:28.041375Z',
+                'status': 'COMPLETE',
+                'source_file': 'http://localhost:7000/media/boundaries/2015/05/13/phila-city_limits_shp_IbasPjb.zip'
+            }]
+        };
+
+        var BoundaryNoGeomResponse = {
+            'count': 1,
+            'next': null,
+            'previous': null,
+            'results': [{
+                'uuid': '7c2acfe7-ccf0-4245-9799-f4fa7d80bd9d',
+                'data': {
+                    'PROVINCE': '',
+                    'REGION': 'R2',
+                    'REG_DESC': 'CAGAYAN VALLEY REGION'
+                },
+                'bbox': [
+                    {
+                        'lat': 19.949404944931022,
+                        'lon': 122.1424120222916
+                    },
+                    {
+                        'lat': 19.967709174247037,
+                        'lon': 122.16365427955863
+                    }
+                ],
+                'created': '2015-10-02T13:59:15.210040Z',
+                'modified': '2015-10-02T13:59:15.210084Z',
+                'boundary': '80c10057-2cfc-4a32-8e3c-0573e8bf853f'
+            }]
+        };
+
+        var RecordSchemaResponse = {
+            'count': 1,
+            'next': null,
+            'previous': null,
+            'results': [
+                {
+                    'uuid': '80c10057-2cfc-4a32-8e3c-0573e8bf8f3f',
+                    'schema': {
+                        // Note: the format of this is still in flux and will change a bit
+                        'description': '',
+                        'title': '',
+                        'plural_title': '',
+                        'definitions': {
+                            'Incident Details': {
+                                'description': 'Details of incident',
+                                'title': 'Incident Details',
+                                'plural_title': 'Incident Details',
+                                'definitions': {},
+                                'type': 'object',
+                                'properties': {
+                                    'Description': {
+                                        'fieldType': 'text',
+                                        'format': 'textarea',
+                                        'isSearchable': true,
+                                        'propertyOrder': 0,
+                                        'type': 'string'
+                                    }
+                                },
+                                'details': true
+                            },
+                            'Firearm': {
+                                'description': 'Guns and other projectiles.',
+                                'title': 'Firearm',
+                                'plural_title': 'Firearms',
+                                'definitions': {},
+                                'type': 'object',
+                                'properties': {}
+                            }
+                        },
+                        'type': 'object',
+                        'properties': {
+                            'Incident Details': {
+                                '$ref': '#/definitions/Incident Details'
+                            },
+                            'Firearm': {
+                                '$ref': '#/definitions/Firearm'
+                            }
+                        }
+                    },
+                    'created': '2015-05-13T21:44:28.324760Z',
+                    'modified': '2015-05-13T21:44:28.324819Z',
+                    'version': 2,
+                    'next_version': null,
+                    'record_type': '15460346-65d7-4f4d-944d-27324e224691'
+                }
+            ]
+        };
+
+        var RecordTypeResponse = {
+            'count': 3,
+            'next': null,
+            'previous': null,
+            'results': [
+                {
+                    'uuid':'15460346-65d7-4f4d-944d-27324e224691',
+                    'current_schema':'80c10057-2cfc-4a32-8e3c-0573e8bf8f3f',
+                    'created':'2015-05-13T21:43:29.227598Z',
+                    'modified':'2015-05-13T21:43:29.227639Z',
+                    'label':'Incident',
+                    'plural_label':'Incidents',
+                    'description':'An incident.',
+                    'active':true
+                },
+                {
+                    'uuid': '99eeb841-31cf-4059-a408-070a0853c875',
+                    'current_schema': 'd71e6475-e328-41d3-8e1f-556ab4145129',
+                    'created': '2016-02-02T19:10:58.039863Z',
+                    'modified': '2016-02-02T19:10:58.039897Z',
+                    'label': 'Intervention',
+                    'plural_label': 'Interventions',
+                    'description': 'Actions to improve traffic safety',
+                    'active': true
+                },
+                {
+                    'uuid':'1a8232f4-2fe8-4df0-9c78-786f666b3551',
+                    'current_schema':'311791af-409e-40ac-8209-fe9785469479',
+                    'created':'2015-05-13T21:43:45.242844Z',
+                    'modified':'2015-05-13T21:43:45.242894Z',
+                    'label':'Bird Sighting',
+                    'plural_label':'Bird Sightings',
+                    'description':'Birds and their environments.',
+                    'active':true
+                }
+            ]
+        };
+
+        var BlackSpotConfigResponse = {
+            'count': 1,
+            'next': null,
+            'previous': null,
+            'results': [
+                {
+                    'uuid':'aaa60346-65d7-4f4d-944d-27324e224691',
+                    'created':'2015-05-13T21:43:29.227598Z',
+                    'modified':'2015-05-13T21:43:29.227639Z',
+                    'severity_percentile_threshold': 0.95
+                }
+            ]
+        };
+
+        var RecordType = RecordTypeResponse.results[0];
+
+        var SecondaryRecordType = RecordTypeResponse.results[1];
+
+        var RecordSchemaRequest = angular.extend({}, RecordType, {
+            definitions: {
+                'Incident Details': {
+                    type: 'object',
+                    title: 'Incident Details',
+                    plural_title: 'Incident Details',
+                    description: 'Details for Incident',
+                    multiple: false,
+                    propertyOrder: 0,
+                    details: true
+                }
+            }
+        });
+
+        var UserInfoResponse = {
+            'id': 2,
+            'url': 'http://localhost:7000/api/users/2/',
+            'username': '0000000000000000000',
+            'email': 'test@azavea.com',
+            'groups': ['public'],
+            'isAdmin': false,
+            'is_staff': false,
+            'is_superuser': false
+        };
+
+        var AdminUserInfoResponse = {
+            'id': 1,
+            'url': 'http://localhost:7000/api/users/1/',
+            'username': '0000000000000000000',
+            'email': 'admin@azavea.com',
+            'groups': ['admin'],
+            'isAdmin': true,
+            'is_staff': false,
+            'is_superuser': false
+        };
+
+        var UsersResponse = {
+            'count': 4,
+            'next': null,
+            'previous': null,
+            'results': [
+                {
+                    'id': 2,
+                    'url': 'http://localhost:7000/api/users/2/',
+                    'username': '0000000000000000000',
+                    'email': 'test@azavea.com',
+                    'groups': ['public'],
+                    'isAdmin': false,
+                    'is_staff': false,
+                    'is_superuser': false
+                }, {
+                    'id': 1,
+                    'url': 'http://localhost:7000/api/users/1/',
+                    'username': '0000000000000000000',
+                    'email': 'admin@azavea.com',
+                    'groups': ['admin'],
+                    'isAdmin': true,
+                    'is_staff': false,
+                    'is_superuser': false
+                }
+            ]
+        };
+
+        var RecordList = [
+            {
+                'uuid': '35d74ce1-7b08-486b-b791-da9bc1e93cfb',
+                'archived': false,
+                'data': {
+                    'Person': [],
+                    'Crime Details': {
+                        'County': 'Philadelphia',
+                        'Description': 'First test',
+                        'District': '13',
+                        '_localId': 'e116f30b-e493-4d57-9797-a901abddf7d5'
+                    },
+                    'Vehicle': []
+                },
+                'created': '2015-07-30T17:36:29.483160Z',
+                'modified': '2015-07-30T17:36:29.483206Z',
+                'occurred_from': '2015-07-30T17:36:29.263000Z',
+                'occurred_to': '2015-07-30T17:36:29.263000Z',
+                'geom': {
+                    'type': 'Point',
+                    'coordinates': [
+                        25.0,
+                        75.0
+                    ]
+                },
+                'location_text': '',
+                'schema': 'db446730-3d6d-40b3-8699-0027205d54ed'
+            },
+            {
+                'uuid': '57dd6700-6e87-4110-ab11-dc7eefc50c96',
+                'archived': false,
+                'data': {
+                    'Person': [
+                        {
+                            'Last name': 'John',
+                            'First name': 'Smith',
+                            'Street address': '3 Test St.',
+                            '_localId': '4cde1cc9-2cd2-487b-983d-ae1de1d6198c'
+                        },
+                        {
+                            'Last name': 'Jane',
+                            'First name': 'Doe',
+                            'Street address': '4 Test Ln.',
+                            '_localId': 'b383cf8c-95f2-46de-aaed-d05115db8d4d'
+                        }
+                    ],
+                    'Crime Details': {
+                        'County': 'Philadelphia',
+                        'Description': 'Second test',
+                        'District': '14',
+                        '_localId': '2382abab-0958-4aef-a1f6-ccca379ae9a4'
+                    },
+                    'location_text': '',
+                    'schema': 'db446730-3d6d-40b3-8699-0027205d54ed'
+                }
+            },
+            {
+                "uuid": "80621b6f-4036-45c5-940b-796f23ea0185",
+                "data": {
+                    "interventionDetails": {
+                        "Type": "Intersection - Roundabout",
+                        "_localId": "dddb643b-18ae-4b3d-8eba-e3d59c7fb14f"
+                    }
+                },
+                "created": "2016-02-02T19:11:00.479893Z",
+                "modified": "2016-02-02T19:11:00.479924Z",
+                "occurred_from": "2016-02-02T06:11:00.395264Z",
+                "occurred_to": "2016-02-02T06:11:00.395273Z",
+                "geom": {
+                    "type": "Point",
+                    "coordinates": [
+                        121.03756381620197,
+                        14.644203676970669
+                    ]
+                },
+                "location_text": null,
+                "city": null,
+                "city_district": null,
+                "county": null,
+                "neighborhood": null,
+                "road": null,
+                "state": null,
+                "weather": null,
+                "light": null,
+                "schema": "d71e6475-e328-41d3-8e1f-556ab4145129"
+            }
+        ];
+
+        var RecordResponse = {
+            'count': 3,
+            'next': null,
+            'previous': null,
+            'results': RecordList
+        };
+
+        var module = {
+            BlackSpotConfigResponse: BlackSpotConfigResponse,
+            GeographyResponse: GeographyResponse,
+            BoundaryNoGeomResponse: BoundaryNoGeomResponse,
+            RecordSchema: RecordSchemaResponse.results[0],
+            RecordSchemaResponse: RecordSchemaResponse,
+            RecordSchemaRequest: RecordSchemaRequest,
+            RecordType: RecordType,
+            SecondaryRecordType: SecondaryRecordType,
+            RecordTypeResponse: RecordTypeResponse,
+            UserInfoResponse: UserInfoResponse,
+            AdminUserInfoResponse: AdminUserInfoResponse,
+            UsersResponse: UsersResponse,
+            RecordResponse: RecordResponse
+        };
+        return module;
+    }
+
+    angular.module('ase.mock.resources', [])
+    .factory('ResourcesMock', ResourcesMock);
+
+})();

--- a/test/spec/auth/auth-service.spec.js
+++ b/test/spec/auth/auth-service.spec.js
@@ -1,0 +1,132 @@
+'use strict';
+
+describe('ase.auth:AuthService', function () {
+
+    beforeEach(module('ase.mock.resources'));
+    beforeEach(module('ase.userdata'));
+    beforeEach(module('ase.auth'));
+
+    var $httpBackend;
+    var $rootScope;
+    var $q;
+    var $timeout;
+
+    var AuthService;
+    var ResourcesMock;
+    var UserService;
+    var queryUrl = /\/api-token-auth/;
+
+    beforeEach(function() {
+        var $window;
+        var $cookies;
+
+        module(function ($provide) {
+            // mock UserService
+            $provide.factory('UserService', function() {
+                return {
+                    canWriteRecords: function() { return {
+                            then: function(callback) {
+                                return callback(true); // analyst
+                            }
+                        };
+                    },
+                    isAdmin: function() { return {
+                            then: function(callback) {
+                                return callback(false); // not an admin
+                            }
+                        };
+                    }
+                };
+            });
+
+            // avoid full page reload during test
+            $window = {
+                location: {},
+                document: window.document,
+                reload: jasmine.createSpy()
+            };
+
+            $provide.constant('$window', $window);
+        });
+
+        inject(function(_$cookies_, _$httpBackend_, _$rootScope_, _$window_, _$q_, _$timeout_,
+               _AuthService_, _ResourcesMock_, _UserService_) {
+
+            AuthService = _AuthService_;
+            UserService = _UserService_;
+            ResourcesMock = _ResourcesMock_;
+            $httpBackend = _$httpBackend_;
+            $q = _$q_;
+            $timeout = _$timeout_;
+            $rootScope = _$rootScope_;
+            $window = _$window_;
+            $cookies = _$cookies_;
+            spyOn($rootScope, '$broadcast');
+        });
+
+        // clear cookies
+        angular.forEach($cookies.getAll(), function(value, key) {
+            $cookies.remove(key);
+        });
+    });
+
+    it('should log in and back out successfully', function () {
+        // log in
+        $httpBackend.expectPOST(queryUrl).respond({user: 1, token: 'gotatoken'});
+        AuthService.authenticate({username: 'foo', password: 'foo'}).then(function(data) {
+            expect(data.isAuthenticated).toBe(true);
+            expect(data.status).toBe(200);
+            expect(data.error).toBeFalsy();
+            expect($rootScope.$broadcast).toHaveBeenCalledWith(AuthService.events.loggedIn);
+            expect(AuthService.hasWriteAccess()).toBeTruthy();
+            expect(AuthService.getUserId()).toBe(1);
+            expect(AuthService.getToken()).toBe('gotatoken');
+        });
+
+        $httpBackend.flush();
+        $timeout.flush();
+
+        // log out
+        AuthService.logout();
+        $rootScope.$digest();
+        $timeout.flush();
+        expect(AuthService.getUserId()).toBe(-1);
+        expect(AuthService.getToken()).toBeUndefined();
+        expect(AuthService.hasWriteAccess()).toBeFalsy();
+        expect($rootScope.$broadcast).toHaveBeenCalledWith(AuthService.events.loggedOut);
+    });
+
+    it('should handle authentication failure', function () {
+        $httpBackend.expectPOST(queryUrl).respond(400, {password: ['This field may not be blank.']});
+
+        AuthService.authenticate({username: 'foo'}).then(function(data) {
+            expect(data.isAuthenticated).toBe(false);
+            expect(data.status).toBe(400);
+            expect(data.error).toBe('Password field required.');
+            expect(AuthService.getUserId()).toBe(-1);
+            expect(AuthService.getToken()).toBeUndefined();
+            expect(AuthService.hasWriteAccess()).toBeFalsy();
+        });
+
+        $httpBackend.flush();
+        $timeout.flush();
+    });
+
+    it('should support restricting to admin logins', function () {
+        // attempt to log in with non-admin user to admin portion of site
+        $httpBackend.expectPOST(queryUrl).respond({user: 1, token: 'gotatoken'});
+        AuthService.authenticate({username: 'foo', password: 'foo'}, true).then(function(data) {
+            expect(data.isAuthenticated).toBe(false);
+            expect(data.status).toBe(200);
+            expect(data.error).toBeTruthy();
+            expect(AuthService.getUserId()).toBe(-1);
+            expect(AuthService.getToken()).toBeUndefined();
+            expect(AuthService.hasWriteAccess()).toBeFalsy();
+        });
+
+        $rootScope.$digest();
+        $httpBackend.flush();
+        $timeout.flush();
+    });
+
+});

--- a/test/spec/directives/confirm-click-directive.spec.js
+++ b/test/spec/directives/confirm-click-directive.spec.js
@@ -1,0 +1,27 @@
+'use strict';
+
+describe('ase.directives: ConfirmClick', function () {
+    beforeEach(module('ase.directives'));
+
+    var $compile;
+    var $rootScope;
+    var $window;
+
+    beforeEach(inject(function (_$compile_, _$rootScope_, _$window_) {
+        $compile = _$compile_;
+        $rootScope = _$rootScope_;
+        $window = _$window_;
+    }));
+
+    it('should display confirmation dialog on click', function () {
+        var scope = $rootScope.$new();
+        var element = $compile('<a ase-confirm-click="test"></a>')(scope);
+        $rootScope.$apply();
+
+        spyOn($window, 'confirm');
+
+        element.click();
+
+        expect($window.confirm).toHaveBeenCalled();
+    });
+});

--- a/test/spec/notifications/notifications-controller.spec.js
+++ b/test/spec/notifications/notifications-controller.spec.js
@@ -1,0 +1,52 @@
+'use strict';
+
+describe('ase.notifications: NotificationsController', function () {
+    beforeEach(module('ase.notifications'));
+
+    var $controller;
+    var $rootScope;
+    var $scope;
+    var $timeout;
+    var Controller;
+
+    // Initialize the controller and a mock scope
+    beforeEach(inject(function (_$controller_, _$rootScope_, _$timeout_) {
+        $controller = _$controller_;
+        $rootScope = _$rootScope_;
+        $scope = $rootScope.$new();
+        $timeout = _$timeout_;
+    }));
+
+    it('should set active to true when ase.notifications.show is broadcast', function () {
+        Controller = $controller('NotificationsController', {
+            $scope: $scope
+        });
+        $scope.$apply();
+        expect(Controller.active).toBe(undefined);
+        $rootScope.$broadcast('ase.notifications.show', {});
+        expect(Controller.active).toBe(true);
+    });
+
+    it('should save the alert options sent to it', function () {
+        Controller = $controller('NotificationsController', {
+            $scope: $scope
+        });
+        $scope.$apply();
+        $rootScope.$broadcast('ase.notifications.show', {customAttribute: 'Borgle'});
+        expect(Controller.alert).toBeDefined();
+        expect(Controller.alert.customAttribute).toBeDefined();
+        expect(Controller.alert.customAttribute).toBe('Borgle');
+    });
+
+    it('The alert should be hidden after a timeout if the timeout parameter is set', function () {
+        Controller = $controller('NotificationsController', {
+            $scope: $scope
+        });
+        $scope.$apply();
+        $rootScope.$broadcast('ase.notifications.show', { timeout: 1000 });
+        expect(Controller.active).toBe(true);
+        $timeout(function() {
+            expect(Controller.active).toBe(false);
+        }, 2000);
+    });
+});

--- a/test/spec/notifications/notifications-directive.spec.js
+++ b/test/spec/notifications/notifications-directive.spec.js
@@ -1,0 +1,37 @@
+'use strict';
+
+describe('ase.notifications: Directive', function () {
+    beforeEach(module('ase.templates'));
+    beforeEach(module('ase.notifications'));
+
+    var $compile;
+    var $rootScope;
+
+    beforeEach(inject(function (_$compile_, _$rootScope_) {
+        $compile = _$compile_;
+        $rootScope = _$rootScope_;
+    }));
+
+    it('should load directive with text message', function () {
+        var scope = $rootScope.$new();
+        var element = $compile('<ase-notifications></ase-notifications>')(scope);
+        $rootScope.$apply();
+
+        $rootScope.$broadcast('ase.notifications.show', {text: 'Danger, Will Robinson!'});
+        $rootScope.$apply();
+
+        expect(element.find('table').length).toEqual(1);
+    });
+
+    it('should load directive with HTML message', function () {
+        var scope = $rootScope.$new();
+        var element = $compile('<ase-notifications></ase-notifications>')(scope);
+        $rootScope.$apply();
+
+        $rootScope.$broadcast('ase.notifications.show', {html: '<p>Danger, Will Robinson!</p>'});
+        $rootScope.$apply();
+
+        expect(element.find('div[ng-bind-html]').length).toEqual(1);
+    });
+
+});

--- a/test/spec/notifications/notifications-service.spec.js
+++ b/test/spec/notifications/notifications-service.spec.js
@@ -1,0 +1,45 @@
+'use strict';
+
+describe('ase.notifications: Notifications', function () {
+
+    beforeEach(module('ase.notifications'));
+
+    var Notifications;
+    var $rootScope;
+
+    beforeEach(inject(function (_$rootScope_, _Notifications_) {
+        $rootScope = _$rootScope_;
+        Notifications = _Notifications_;
+    }));
+
+    it('should store and clear the most recently created alert', function () {
+        expect(Notifications.activeAlert()).toBeNull();
+        Notifications.show({customAttribute: 'Borgle'});
+        var activeAlert = Notifications.activeAlert();
+        expect(activeAlert).toBeDefined();
+        expect(activeAlert).not.toBeNull();
+        expect(activeAlert.customAttribute).toBeDefined();
+        expect(activeAlert.customAttribute).toBe('Borgle');
+        Notifications.hide();
+        expect(Notifications.activeAlert()).toBeNull();
+    });
+
+    it('should emit the correct event when show is called', function () {
+        spyOn($rootScope, '$broadcast');
+        Notifications.show({});
+        expect($rootScope.$broadcast).toHaveBeenCalledWith('ase.notifications.show',
+            jasmine.any(Object) // Don't check the default values here.
+        );
+    });
+
+    it('should set sane defaults on newly created alerts', function () {
+        Notifications.show({});
+        var created = Notifications.activeAlert();
+        expect(created.timeout).toBe(0);
+        expect(created.closeButton).toBe(true);
+        expect(created.text).toBe('');
+        expect(created.imageClass).toBe('glyphicon-warning-sign');
+        expect(created.displayClass).toBe('alert-info');
+    });
+});
+

--- a/test/spec/resources/builderschemas-service.spec.js
+++ b/test/spec/resources/builderschemas-service.spec.js
@@ -1,0 +1,34 @@
+'use strict';
+
+describe('ase.resources: BuilderSchemas', function () {
+
+    beforeEach(module('ase.mock.resources'));
+    beforeEach(module('ase.resources'));
+    beforeEach(module('ase.schemas'));
+
+    var $httpBackend;
+    var BuilderSchemas;
+    var ResourcesMock;
+    var Schemas;
+    var schemaEnv = jjv();
+    schemaEnv.addSchema('v4', jsonSchemaV4());
+
+    beforeEach(inject(function (_$httpBackend_, _BuilderSchemas_, _ResourcesMock_, _Schemas_) {
+        $httpBackend = _$httpBackend_;
+        BuilderSchemas = _BuilderSchemas_;
+        ResourcesMock = _ResourcesMock_;
+        Schemas = _Schemas_;
+    }));
+
+    it('should load valid related schema', function () {
+        var relatedBuilderSchema = readJSON('app/builder-schemas/related.json');
+        var requestUrl = /builder-schemas\/related\.json/;
+        $httpBackend.whenGET(requestUrl).respond(relatedBuilderSchema);
+
+        BuilderSchemas.get({ name: 'related' }).$promise.then(function (schema) {
+            expect(schemaEnv.validate('v4', schema)).toBe(null);
+        });
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+});

--- a/test/spec/resources/geography-service.spec.js
+++ b/test/spec/resources/geography-service.spec.js
@@ -1,0 +1,30 @@
+'use strict';
+
+describe('ase.resources: Geography', function () {
+
+    beforeEach(module('ase.mock.resources'));
+    beforeEach(module('ase.resources'));
+
+    var $httpBackend;
+    var Geography;
+    var ResourcesMock;
+
+    beforeEach(inject(function (_$httpBackend_, _Geography_, _ResourcesMock_) {
+        $httpBackend = _$httpBackend_;
+        Geography = _Geography_;
+        ResourcesMock = _ResourcesMock_;
+    }));
+
+    it('should extract geographies from paginated response', function () {
+        var requestUrl = /\/api\/boundaries/;
+        $httpBackend.whenGET(requestUrl).respond(ResourcesMock.GeographyResponse);
+        Geography.query().$promise.then(function (data) {
+            expect(data.length).toBe(1);
+
+            var geography = data[0];
+            expect(geography.uuid).toEqual('80c10057-2cfc-4a32-8e3c-0573e8bf853f');
+        });
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+});

--- a/test/spec/resources/recordschemas-service.spec.js
+++ b/test/spec/resources/recordschemas-service.spec.js
@@ -1,0 +1,30 @@
+'use strict';
+
+describe('ase.resources: RecordSchemas', function () {
+
+    beforeEach(module('ase.mock.resources'));
+    beforeEach(module('ase.resources'));
+
+    var $httpBackend;
+    var RecordSchemas;
+    var ResourcesMock;
+
+    beforeEach(inject(function (_$httpBackend_, _RecordSchemas_, _ResourcesMock_) {
+        $httpBackend = _$httpBackend_;
+        RecordSchemas = _RecordSchemas_;
+        ResourcesMock = _ResourcesMock_;
+    }));
+
+    it('should extract record schemas from paginated response', function () {
+        var requestUrl = /\/api\/recordschemas/;
+        $httpBackend.whenGET(requestUrl).respond(ResourcesMock.RecordSchemaResponse);
+        RecordSchemas.query().$promise.then(function (data) {
+            expect(data.length).toBe(1);
+
+            var recordSchema = data[0];
+            expect(recordSchema.schema).toEqual(jasmine.any(Object));
+        });
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+});

--- a/test/spec/resources/recordtypes-service.spec.js
+++ b/test/spec/resources/recordtypes-service.spec.js
@@ -1,0 +1,30 @@
+'use strict';
+
+describe('ase.resources: RecordTypes', function () {
+
+    beforeEach(module('ase.mock.resources'));
+    beforeEach(module('ase.resources'));
+
+    var $httpBackend;
+    var RecordTypes;
+    var ResourcesMock;
+
+    beforeEach(inject(function (_$httpBackend_, _RecordTypes_, _ResourcesMock_) {
+        $httpBackend = _$httpBackend_;
+        RecordTypes = _RecordTypes_;
+        ResourcesMock = _ResourcesMock_;
+    }));
+
+    it('should extract record types from paginated response', function () {
+        var requestUrl = /\/api\/recordtypes/;
+        $httpBackend.whenGET(requestUrl).respond(ResourcesMock.RecordTypeResponse);
+        RecordTypes.query({ active: 'True' }).$promise.then(function (data) {
+            expect(data.length).toBe(3);
+
+            var recordType = data[0];
+            expect(recordType.label).toEqual(jasmine.any(String));
+        });
+        $httpBackend.flush();
+        $httpBackend.verifyNoOutstandingRequest();
+    });
+});

--- a/test/spec/schemas/schemas-service.spec.js
+++ b/test/spec/schemas/schemas-service.spec.js
@@ -1,0 +1,312 @@
+'use strict';
+
+describe('ase.schemas:Schemas', function () {
+
+    beforeEach(module('ase.schemas'));
+
+    var Schemas;
+    var schemaEnv = jjv();
+    schemaEnv.addSchema('v4', jsonSchemaV4());
+
+    // Initialize the controller and a mock scope
+    beforeEach(inject(function (_Schemas_) {
+        Schemas = _Schemas_;
+    }));
+
+    it('should ensure JsonObject is a valid jsonschema v4', function () {
+        var obj = Schemas.JsonObject();
+        expect(schemaEnv.validate('v4', obj)).toBe(null);
+    });
+
+    it('should add the $schema declaration to schemas', function () {
+        var obj = Schemas.JsonObject();
+        obj = Schemas.addVersion4Declaration(obj);
+        expect(schemaEnv.validate('v4', obj)).toBe(null);
+    });
+
+    it('should serialize schema form outputs to data form schema snippets', function () {
+        var schemaFormData = [{
+            fieldType: 'text',
+            isRequired: false,
+            fieldTitle: 'Text'
+        }];
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
+        expect(dataFormSchemaDef).toEqual(jasmine.objectContaining({
+            properties: jasmine.anything(),
+            type: 'object'
+        }));
+    });
+
+    it('should serialize a textOptions key in text fields', function () {
+        var schemaFormData = [{
+            fieldType: 'text',
+            isRequired: false,
+            fieldTitle: 'Text',
+            textOptions: 'datetime'
+        }];
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
+        expect(dataFormSchemaDef.properties.Text.format).toEqual(schemaFormData[0].textOptions);
+    });
+
+    it('should serialize an isSearchable key', function () {
+        var schemaFormData = [{
+            fieldType: 'text',
+            isRequired: false,
+            isSearchable: true,
+            fieldTitle: 'Text',
+            textOptions: 'datetime'
+        }];
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
+        expect(dataFormSchemaDef.properties.Text.isSearchable)
+            .toEqual(schemaFormData[0].isSearchable);
+    });
+
+    it('should serialize an enum key in selectlist fields', function () {
+        var schemaFormData = [{
+            fieldType: 'selectlist',
+            isRequired: false,
+            fieldTitle: 'Text',
+            fieldOptions: ['opt1', 'opt2', 'opt3']
+        }];
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
+        expect(dataFormSchemaDef.properties.Text['enum']).toEqual(schemaFormData[0].fieldOptions);
+    });
+
+    it('should serialize a displayType key in selectlist fields', function () {
+        var schemaFormData = [{
+            fieldType: 'selectlist',
+            displayType: 'select',
+            isRequired: false,
+            fieldTitle: 'Text',
+            fieldOptions: ['opt1', 'opt2', 'opt3']
+        }];
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
+        expect(dataFormSchemaDef.properties.Text.displayType).toEqual(schemaFormData[0].displayType);
+    });
+
+    it('should serialize a media key in image fields', function () {
+        var schemaFormData = [{
+            fieldType: 'image',
+            isRequired: false,
+            fieldTitle: 'Photo'
+        }];
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
+        expect(dataFormSchemaDef.properties.Photo.media).toBeDefined();
+    });
+
+    it('should properly serialize watch and enumSource keys into reference fields', function () {
+        var schemaFormData = [{
+            fieldType: 'reference',
+            isRequired: false,
+            fieldTitle: 'Reference',
+            referenceTarget: 'OtherType'
+        }];
+        // Stub out only the keys that we need on the existing schema
+        var stubSchema = {
+            definitions: {
+                OtherType: {
+                    properties: {
+                        property1: {},
+                        property2: {},
+                        property3: {}
+                    }
+                }
+            }
+        };
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData,
+            stubSchema,
+            'NotOtherType');
+        expect(dataFormSchemaDef.properties.Reference.watch).toBeDefined();
+        expect(dataFormSchemaDef.properties.Reference.enumSource).toBeDefined();
+        expect(dataFormSchemaDef.properties.Reference.enumSource).toEqual([{
+            source: 'target',
+            title: '{{item.property1}} {{item.property2}} {{item.property3}}',
+            value: '{{item._localId}}'
+        }]);
+    });
+
+    it('should add to the "required" key when fields have isRequired: true', function () {
+        var schemaFormData = [{
+            fieldType: 'selectlist',
+            isRequired: false,
+            fieldTitle: 'Text',
+            fieldOptions: ['opt1', 'opt2', 'opt3']
+        },{
+            fieldType: 'image',
+            isRequired: true,
+            fieldTitle: 'Photo'
+        }];
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
+        expect(dataFormSchemaDef.required.length).toEqual(2); // Everything has required: ['_localId']
+        expect(dataFormSchemaDef.required).toContain('Photo');
+    });
+
+    it('should create a required "_localId" field on all definitions', function () {
+        var schemaFormData = [{
+            fieldType: 'selectlist',
+            isRequired: false,
+            fieldTitle: 'Text',
+            fieldOptions: ['opt1', 'opt2', 'opt3']
+        },{
+            fieldType: 'image',
+            isRequired: false,
+            fieldTitle: 'Photo'
+        }];
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
+        expect(dataFormSchemaDef.required).toBeDefined();
+        expect(dataFormSchemaDef.required.length).toBe(1);
+        expect(dataFormSchemaDef.required).toContain('_localId');
+    });
+
+    it('should calculate and set propertyOrder based on the ordering of fields', function () {
+        var schemaFormData = [];
+        for (var i in [0,1,2,3,4]) {
+            schemaFormData.push({
+                fieldType: 'text',
+                fieldTitle: 'Title' + i,
+                indexShouldBe: i
+            });
+        }
+        var dataFormSchemaDef = Schemas.definitionFromSchemaFormData(schemaFormData);
+        for (var j in [0,1,2,3,4]) {
+            var field = dataFormSchemaDef.properties['Title' + j];
+            expect(field.propertyOrder.toString()).toEqual(j);
+        }
+    });
+
+    it('should validate that no two Schema Entry Form fields have the same title', function () {
+        var schemaFormData = [{
+            fieldType: 'selectlist',
+            isRequired: false,
+            fieldTitle: 'Same1',
+            fieldOptions: ['opt1', 'opt2', 'opt3']
+        },{
+            fieldType: 'image',
+            isRequired: true,
+            fieldTitle: 'Same2'
+        },{
+            fieldType: 'text',
+            isRequired: false,
+            fieldTitle: 'Same1'
+        },{
+            fieldType: 'text',
+            isRequired: false,
+            fieldTitle: 'Diff'
+        },{
+            fieldType: 'text',
+            isRequired: false,
+            fieldTitle: 'Same2'
+        }];
+        var errors = Schemas.validateSchemaFormData(schemaFormData);
+        expect(errors.length).toEqual(2);
+        expect(errors).toEqual(jasmine.arrayContaining([{
+            message: jasmine.stringMatching('Same1')
+        }]));
+        expect(errors).toEqual(jasmine.arrayContaining([{
+            message: jasmine.stringMatching('Same2')
+        }]));
+        expect(errors).not.toEqual(jasmine.arrayContaining([{
+            message: jasmine.stringMatching('Diff')
+        }]));
+    });
+
+    // NOTE: This test must be updated when new field types are added.
+    it('should preserve all information when serializing and deserializing schemas', function () {
+        // In practice this means that the serialize and deserialize methods are inverses
+        var stubSchema = {
+            definitions: {
+                OtherType: {
+                    properties: {
+                        property1: {},
+                        property2: {},
+                        property3: {}
+                    }
+                }
+            }
+        };
+        // The forward and backward functions have different signatures, so we need to "curry"
+        // the forward function so we can pass the results back and forth directly.
+        var f = function(formData) {
+            return Schemas.definitionFromSchemaFormData(formData, stubSchema, 'NotOtherType');
+        };
+        var b = Schemas.schemaFormDataFromDefinition;
+
+        var schemaFormData = [{
+            fieldType: 'selectlist',
+            isSearchable: false,
+            displayType: 'checkbox',
+            isRequired: false,
+            fieldTitle: 'Select',
+            fieldOptions: ['opt1', 'opt2'],
+            propertyOrder: 0 // The serializer uses the ordering of the incoming form data to
+                             // determine and set the propertyOrder value, since this is how
+                             // JSON-Editor expresses the value. Therefore this value must match
+                             // the ordering of the array in order to ensure that the output
+                             // matches the input, otherwise the serializer will assume that the
+                             // ordering has changed and update the propertyOrder field, causing
+                             // the test to fail.
+        },{
+            fieldType: 'number',
+            isSearchable: true,
+            isRequired: false,
+            fieldTitle: 'Number Field',
+            minimum: undefined,
+            maximum: undefined,
+            propertyOrder: 1
+        },{
+            fieldType: 'image',
+            isSearchable: false,
+            isRequired: true,
+            fieldTitle: 'Image',
+            propertyOrder: 2
+        },{
+            fieldType: 'text',
+            isSearchable: false,
+            isRequired: false,
+            fieldTitle: 'Text',
+            textOptions: 'datetime',
+            propertyOrder: 3
+        },{
+            fieldType: 'reference',
+            isRequired: false,
+            isSearchable: false,
+            fieldTitle: 'Local reference',
+            referenceTarget: 'OtherType',
+            propertyOrder: 4
+        }];
+
+        // Transform back and forth a few times
+        var output = b(f(b(f(b(f(b(f(b(f(b(f(schemaFormData))))))))))));
+        expect(output).toEqual(schemaFormData);
+
+        // Ensure all field types are represented in this test
+        var formDataFields = _.map(schemaFormData, 'fieldType').sort();
+        var schemaFields = _.keys(Schemas.FieldTypes).sort();
+        expect(formDataFields).toEqual(jasmine.objectContaining(schemaFields));
+    });
+
+    it('should sort by propertyOrder when deserializing schemas', function () {
+        var definition = {
+            properties: {
+                appearsSecond: {
+                    fieldType: 'text',
+                    propertyOrder: 1
+                },
+                appearsThird: {
+                    fieldType: 'text',
+                    propertyOrder: 2
+                },
+                appearsFirst: {
+                    fieldType: 'text',
+                    propertyOrder: 0
+                }
+            }
+        };
+
+        var formData = Schemas.schemaFormDataFromDefinition(definition);
+        for (var i = 1; i < formData.length; i++) {
+            expect(formData[i].propertyOrder).toBeGreaterThan(formData[i-1].propertyOrder);
+        }
+    });
+
+});


### PR DESCRIPTION
# Overview

This PR pulls out the relevant components of the schema editor from https://github.com/azavea/ashlar-blueprint and brings them into this repo.

## Notes

- Most of the app code in this repo is adapted directly from https://github.com/azavea/ashlar-blueprint. Only the development scripts (everything in `scripts/` as well as the `.travis.yml` file) are new, so only those should require review in my opinion.

- As I was pulling these components out, I got a better appreciation for why @ddohler was wondering about the difference between [ashlar-server](https://github.com/azavea/ashlar-server) and [ashlar-blueprint](https://github.com/azavea/ashlar-blueprint). The schema editor in particular is so tightly-coupled to a running instance of Ashlar that in the long run it may not make sense to keep this repo separate from ashlar-server, which provides that running instance. However, moving forward I have a vague desire to allow as many different deployment configurations of Ashlar as possible, so the idea of allowing someone to run their own Ashlar instance with their own configuration and then pull this repo in on top of it is still appealing to me, at least for now. If as time goes on it seems that ashlar-server is a necessary requirement of this repo in all cases, then we should consider merging them.

## Testing instructions

- Travis will run the unit tests, but if you'd like to run them locally you can use the development scripts:

```bash
# Build a container for the tests
./scripts/update

# Run the tests
./scripts/test
```